### PR TITLE
Update automerge benchmarks to use automerge.next

### DIFF
--- a/benchmarks/automerge/factory.js
+++ b/benchmarks/automerge/factory.js
@@ -1,10 +1,10 @@
 import { AbstractCrdt, CrdtFactory } from '../../js-lib/index.js' // eslint-disable-line
-import * as automerge from '@automerge/automerge'
+import { next as automerge } from '@automerge/automerge'
 
 const initialDoc = automerge.from({
   array: /** @type {Array<any>} */ ([]),
   map: {},
-  text: new automerge.Text()
+  text: "",
 })
 
 const initialDocBinary = automerge.save(initialDoc)
@@ -101,7 +101,7 @@ export class AutomergeCRDT {
    */
   insertText (index, text) {
     this.doc = automerge.change(this.doc, d => {
-      d.text.insertAt(index, text)
+      automerge.splice(d, ["text"], index, 0, text)
     })
     this.update()
   }
@@ -114,7 +114,7 @@ export class AutomergeCRDT {
    */
   deleteText (index, len) {
     this.doc = automerge.change(this.doc, d => {
-      d.text.deleteAt(index, len)
+      automerge.splice(d, ["text"], index, len, "")
     })
     this.update()
   }
@@ -139,7 +139,19 @@ export class AutomergeCRDT {
    */
   setMap (key, val) {
     this.doc = automerge.change(this.doc, d => {
-      d.map[key] = val
+      // the b3.3 benchmark creates 30,000 javascript strings and adds them to
+      // a map. `string` in automerge is represented as a sequence CRDT. This
+      // many instances of the CRDT currently uses a large amount of memory, to
+      // avoid this we use the `RawString` type, which is not a CRDT but just a
+      // plain string and consequently presents a more like-for-like comparison
+      // with yjs.
+      //
+      // See: https://github.com/automerge/automerge/issues/705
+      if (typeof val === 'string') {
+        d.map[key] = new automerge.RawString(val)
+      } else {
+        d.map[key] = val
+      }
     })
     this.update()
   }
@@ -148,6 +160,17 @@ export class AutomergeCRDT {
    * @return {Map<string,any> | Object<string, any>}
    */
   getMap () {
-    return this.doc.map
+    // Due to the use of `RawString` described in `setMap` we need to convert
+    // all the values in the map to plain strings before returning the map so
+    // that the comparison checks the benchmark makes are valid.
+    const result = {}
+    for (const [key, value] of Object.entries(this.doc.map)) {
+      if (value instanceof automerge.RawString) {
+        result[key] = value.toString()
+      } else {
+        result[key] = value
+      }
+    }
+    return result
   }
 }


### PR DESCRIPTION
The recommended way to use automerge is the `next` API [1]. Update the benchmarks to use this API. This required two changes:

1. Use a plain `string` in the place of the `automerge.Text` type for the `initialDoc.text` field. This is because in `automerge.next` the `string` is represented as a sequence CRDT in the document.
2. For the same reason add some logic in `setMap` which checks if the value that is being inserted into a map is a `string` and if so converts it to a `RawString`, which is not a sequence CRDT. This makes the comparison with yjs more like-for-like

[1]: https://automerge.org/docs/the_js_packages/#the-next-api

This partially addresses #21 