### PR TITLE
Add benchmarks for Loro

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,135 +97,135 @@ re-enable this feature by uncommenting  You can re-enable this feature in
 CRDT](https://github.com/gritzko/ron) (written in C++) are posted [in this
 thread](https://github.com/dmonad/crdt-benchmarks/issues/3).
 
-|N = 6000 | [yjs](https://github.com/yjs/yjs) | [ywasm](https://github.com/y-crdt/y-crdt/tree/main/ywasm) | [automerge](https://github.com/automerge/automerge/) |
-| :- |  -: | -: | -:  |
-|Version                                                                   |          13.6.11 |            0.9.3 |           2.1.10 |
-|Bundle size                                                               |     80,413 bytes |    799,327 bytes |  1,737,571 bytes |
-|Bundle size (gzipped)                                                     |     23,571 bytes |    232,727 bytes |    604,118 bytes |
-|[B1.1] Append N characters (time)                                         |           164 ms |           135 ms |           364 ms |
-|[B1.1] Append N characters (avgUpdateSize)                                |         27 bytes |         27 bytes |        121 bytes |
-|[B1.1] Append N characters (encodeTime)                                   |             1 ms |             1 ms |             7 ms |
-|[B1.1] Append N characters (docSize)                                      |      6,031 bytes |      6,031 bytes |      3,992 bytes |
-|[B1.1] Append N characters (memUsed)                                      |              0 B |              0 B |              0 B |
-|[B1.1] Append N characters (parseTime)                                    |            46 ms |            43 ms |            95 ms |
-|[B1.2] Insert string of length N (time)                                   |             1 ms |             0 ms |             9 ms |
-|[B1.2] Insert string of length N (avgUpdateSize)                          |      6,031 bytes |      6,031 bytes |      6,201 bytes |
-|[B1.2] Insert string of length N (encodeTime)                             |             1 ms |             0 ms |             3 ms |
-|[B1.2] Insert string of length N (docSize)                                |      6,031 bytes |      6,031 bytes |      3,974 bytes |
-|[B1.2] Insert string of length N (memUsed)                                |         192.4 kB |         424.3 kB |           9.2 kB |
-|[B1.2] Insert string of length N (parseTime)                              |            56 ms |            44 ms |            43 ms |
-|[B1.3] Prepend N characters (time)                                        |           132 ms |            21 ms |           314 ms |
-|[B1.3] Prepend N characters (avgUpdateSize)                               |         27 bytes |         27 bytes |        116 bytes |
-|[B1.3] Prepend N characters (encodeTime)                                  |             3 ms |             0 ms |             5 ms |
-|[B1.3] Prepend N characters (docSize)                                     |      6,041 bytes |      6,041 bytes |      3,988 bytes |
-|[B1.3] Prepend N characters (memUsed)                                     |           1.2 MB |           8.3 kB |              0 B |
-|[B1.3] Prepend N characters (parseTime)                                   |            85 ms |            50 ms |            96 ms |
-|[B1.4] Insert N characters at random positions (time)                     |           145 ms |           130 ms |           314 ms |
-|[B1.4] Insert N characters at random positions (avgUpdateSize)            |         29 bytes |         29 bytes |        121 bytes |
-|[B1.4] Insert N characters at random positions (encodeTime)               |             7 ms |             1 ms |             9 ms |
-|[B1.4] Insert N characters at random positions (docSize)                  |     29,554 bytes |     29,554 bytes |     24,743 bytes |
-|[B1.4] Insert N characters at random positions (memUsed)                  |           1.1 MB |              0 B |           9.5 kB |
-|[B1.4] Insert N characters at random positions (parseTime)                |            90 ms |            43 ms |           106 ms |
-|[B1.5] Insert N words at random positions (time)                          |           166 ms |           438 ms |           515 ms |
-|[B1.5] Insert N words at random positions (avgUpdateSize)                 |         36 bytes |         36 bytes |        131 bytes |
-|[B1.5] Insert N words at random positions (encodeTime)                    |            10 ms |             1 ms |            23 ms |
-|[B1.5] Insert N words at random positions (docSize)                       |     87,924 bytes |     87,924 bytes |     96,203 bytes |
-|[B1.5] Insert N words at random positions (memUsed)                       |           2.3 MB |            720 B |              0 B |
-|[B1.5] Insert N words at random positions (parseTime)                     |            74 ms |            48 ms |           171 ms |
-|[B1.6] Insert string, then delete it (time)                               |             2 ms |             1 ms |            24 ms |
-|[B1.6] Insert string, then delete it (avgUpdateSize)                      |      6,053 bytes |      6,053 bytes |      6,338 bytes |
-|[B1.6] Insert string, then delete it (encodeTime)                         |             0 ms |             0 ms |             4 ms |
-|[B1.6] Insert string, then delete it (docSize)                            |         38 bytes |         38 bytes |      3,993 bytes |
-|[B1.6] Insert string, then delete it (memUsed)                            |          65.7 kB |              0 B |           2.2 kB |
-|[B1.6] Insert string, then delete it (parseTime)                          |            59 ms |            43 ms |            67 ms |
-|[B1.7] Insert/Delete strings at random positions (time)                   |           171 ms |           137 ms |           462 ms |
-|[B1.7] Insert/Delete strings at random positions (avgUpdateSize)          |         31 bytes |         31 bytes |        135 bytes |
-|[B1.7] Insert/Delete strings at random positions (encodeTime)             |             8 ms |             1 ms |            21 ms |
-|[B1.7] Insert/Delete strings at random positions (docSize)                |     28,377 bytes |     28,377 bytes |     59,281 bytes |
-|[B1.7] Insert/Delete strings at random positions (memUsed)                |           1.2 MB |            480 B |              0 B |
-|[B1.7] Insert/Delete strings at random positions (parseTime)              |            93 ms |            46 ms |           136 ms |
-|[B1.8] Append N numbers (time)                                            |           160 ms |            26 ms |           455 ms |
-|[B1.8] Append N numbers (avgUpdateSize)                                   |         32 bytes |         32 bytes |        125 bytes |
-|[B1.8] Append N numbers (encodeTime)                                      |             4 ms |             0 ms |            10 ms |
-|[B1.8] Append N numbers (docSize)                                         |     35,634 bytes |     35,634 bytes |     26,985 bytes |
-|[B1.8] Append N numbers (memUsed)                                         |              0 B |              0 B |          63.8 kB |
-|[B1.8] Append N numbers (parseTime)                                       |            66 ms |            43 ms |           101 ms |
-|[B1.9] Insert Array of N numbers (time)                                   |             5 ms |             3 ms |            40 ms |
-|[B1.9] Insert Array of N numbers (avgUpdateSize)                          |     35,657 bytes |     35,657 bytes |     31,199 bytes |
-|[B1.9] Insert Array of N numbers (encodeTime)                             |             1 ms |             0 ms |             5 ms |
-|[B1.9] Insert Array of N numbers (docSize)                                |     35,657 bytes |     35,657 bytes |     26,953 bytes |
-|[B1.9] Insert Array of N numbers (memUsed)                                |          45.6 kB |            552 B |          37.9 kB |
-|[B1.9] Insert Array of N numbers (parseTime)                              |            58 ms |            42 ms |            68 ms |
-|[B1.10] Prepend N numbers (time)                                          |           129 ms |            27 ms |           530 ms |
-|[B1.10] Prepend N numbers (avgUpdateSize)                                 |         32 bytes |         36 bytes |        120 bytes |
-|[B1.10] Prepend N numbers (encodeTime)                                    |             6 ms |             1 ms |             8 ms |
-|[B1.10] Prepend N numbers (docSize)                                       |     35,665 bytes |     65,658 bytes |     26,987 bytes |
-|[B1.10] Prepend N numbers (memUsed)                                       |           1.9 MB |              0 B |          65.7 kB |
-|[B1.10] Prepend N numbers (parseTime)                                     |            73 ms |            45 ms |           106 ms |
-|[B1.11] Insert N numbers at random positions (time)                       |           144 ms |           149 ms |           470 ms |
-|[B1.11] Insert N numbers at random positions (avgUpdateSize)              |         34 bytes |         34 bytes |        125 bytes |
-|[B1.11] Insert N numbers at random positions (encodeTime)                 |             8 ms |             1 ms |            11 ms |
-|[B1.11] Insert N numbers at random positions (docSize)                    |     59,137 bytes |     59,152 bytes |     47,746 bytes |
-|[B1.11] Insert N numbers at random positions (memUsed)                    |           2.1 MB |              0 B |          60.1 kB |
-|[B1.11] Insert N numbers at random positions (parseTime)                  |            93 ms |            51 ms |           104 ms |
-|[B2.1] Concurrently insert string of length N at index 0 (time)           |             3 ms |             0 ms |            71 ms |
-|[B2.1] Concurrently insert string of length N at index 0 (updateSize)     |      6,093 bytes |      6,094 bytes |      9,499 bytes |
-|[B2.1] Concurrently insert string of length N at index 0 (encodeTime)     |             0 ms |             0 ms |             6 ms |
-|[B2.1] Concurrently insert string of length N at index 0 (docSize)        |     12,150 bytes |     12,152 bytes |      8,011 bytes |
-|[B2.1] Concurrently insert string of length N at index 0 (memUsed)        |          76.2 kB |            304 B |          14.5 kB |
-|[B2.1] Concurrently insert string of length N at index 0 (parseTime)      |            62 ms |            41 ms |            64 ms |
-|[B2.2] Concurrently insert N characters at random positions (time)        |            72 ms |           405 ms |           311 ms |
-|[B2.2] Concurrently insert N characters at random positions (updateSize)  |     33,444 bytes |    177,007 bytes |     27,476 bytes |
-|[B2.2] Concurrently insert N characters at random positions (encodeTime)  |             2 ms |             1 ms |            10 ms |
-|[B2.2] Concurrently insert N characters at random positions (docSize)     |     66,860 bytes |     66,852 bytes |     50,683 bytes |
-|[B2.2] Concurrently insert N characters at random positions (memUsed)     |           2.4 MB |            480 B |              0 B |
-|[B2.2] Concurrently insert N characters at random positions (parseTime)   |            65 ms |            52 ms |            67 ms |
-|[B2.3] Concurrently insert N words at random positions (time)             |            86 ms |         1,046 ms |           701 ms |
-|[B2.3] Concurrently insert N words at random positions (updateSize)       |     88,994 bytes |    215,213 bytes |    122,485 bytes |
-|[B2.3] Concurrently insert N words at random positions (encodeTime)       |             4 ms |             4 ms |            37 ms |
-|[B2.3] Concurrently insert N words at random positions (docSize)          |    178,137 bytes |    178,137 bytes |    185,019 bytes |
-|[B2.3] Concurrently insert N words at random positions (memUsed)          |           5.6 MB |            432 B |              0 B |
-|[B2.3] Concurrently insert N words at random positions (parseTime)        |            76 ms |            73 ms |           190 ms |
-|[B2.4] Concurrently insert & delete (time)                                |           232 ms |         2,740 ms |         1,113 ms |
-|[B2.4] Concurrently insert & delete (updateSize)                          |    139,517 bytes |    398,881 bytes |    298,810 bytes |
-|[B2.4] Concurrently insert & delete (encodeTime)                          |            21 ms |             7 ms |            62 ms |
-|[B2.4] Concurrently insert & delete (docSize)                             |    279,172 bytes |    279,172 bytes |    293,829 bytes |
-|[B2.4] Concurrently insert & delete (memUsed)                             |           9.4 MB |            432 B |              0 B |
-|[B2.4] Concurrently insert & delete (parseTime)                           |           142 ms |            84 ms |           278 ms |
-|[B3.1] 20√N clients concurrently set number in Map (time)                 |            91 ms |           276 ms |         1,616 ms |
-|[B3.1] 20√N clients concurrently set number in Map (updateSize)           |     49,181 bytes |     49,169 bytes |    283,296 bytes |
-|[B3.1] 20√N clients concurrently set number in Map (encodeTime)           |             4 ms |             2 ms |            12 ms |
-|[B3.1] 20√N clients concurrently set number in Map (docSize)              |     32,246 bytes |     32,213 bytes |     86,170 bytes |
-|[B3.1] 20√N clients concurrently set number in Map (memUsed)              |         196.3 kB |            272 B |              0 B |
-|[B3.1] 20√N clients concurrently set number in Map (parseTime)            |           100 ms |            77 ms |            48 ms |
-|[B3.2] 20√N clients concurrently set Object in Map (time)                 |            84 ms |           284 ms |         1,727 ms |
-|[B3.2] 20√N clients concurrently set Object in Map (updateSize)           |     85,082 bytes |     85,069 bytes |    398,090 bytes |
-|[B3.2] 20√N clients concurrently set Object in Map (encodeTime)           |             4 ms |             2 ms |            32 ms |
-|[B3.2] 20√N clients concurrently set Object in Map (docSize)              |     32,241 bytes |     32,218 bytes |    112,588 bytes |
-|[B3.2] 20√N clients concurrently set Object in Map (memUsed)              |         232.4 kB |              0 B |              0 B |
-|[B3.2] 20√N clients concurrently set Object in Map (parseTime)            |            93 ms |            75 ms |            93 ms |
-|[B3.3] 20√N clients concurrently set String in Map (time)                 |            88 ms |           299 ms |         2,644 ms |
-|[B3.3] 20√N clients concurrently set String in Map (updateSize)           |  7,826,225 bytes |  7,826,232 bytes |  8,063,440 bytes |
-|[B3.3] 20√N clients concurrently set String in Map (encodeTime)           |             4 ms |             1 ms |           105 ms |
-|[B3.3] 20√N clients concurrently set String in Map (docSize)              |     38,370 bytes |     35,296 bytes |     98,003 bytes |
-|[B3.3] 20√N clients concurrently set String in Map (memUsed)              |         179.2 kB |            200 B |              0 B |
-|[B3.3] 20√N clients concurrently set String in Map (parseTime)            |           104 ms |            86 ms |           130 ms |
-|[B3.4] 20√N clients concurrently insert text in Array (time)              |            75 ms |           283 ms |         2,726 ms |
-|[B3.4] 20√N clients concurrently insert text in Array (updateSize)        |     52,743 bytes |     52,740 bytes |    311,830 bytes |
-|[B3.4] 20√N clients concurrently insert text in Array (encodeTime)        |             2 ms |             1 ms |            18 ms |
-|[B3.4] 20√N clients concurrently insert text in Array (docSize)           |     26,588 bytes |     26,585 bytes |     96,446 bytes |
-|[B3.4] 20√N clients concurrently insert text in Array (memUsed)           |         720.9 kB |           5.5 kB |          38.2 kB |
-|[B3.4] 20√N clients concurrently insert text in Array (parseTime)         |            76 ms |            76 ms |            59 ms |
-|[B4] Apply real-world editing dataset (time)                              |         1,803 ms |        43,943 ms |        12,746 ms |
-|[B4] Apply real-world editing dataset (encodeTime)                        |            12 ms |             4 ms |           219 ms |
-|[B4] Apply real-world editing dataset (docSize)                           |    159,929 bytes |    159,929 bytes |    129,116 bytes |
-|[B4] Apply real-world editing dataset (parseTime)                         |            38 ms |            17 ms |         2,115 ms |
-|[B4] Apply real-world editing dataset (memUsed)                           |           3.5 MB |            856 B |         139.6 kB |
-|[B4x100] Apply real-world editing dataset 100 times (time)                |       199,319 ms |     2,732,719 ms |          skipped |
-|[B4x100] Apply real-world editing dataset 100 times (encodeTime)          |           388 ms |           209 ms |          skipped |
-|[B4x100] Apply real-world editing dataset 100 times (docSize)             | 15,989,245 bytes | 15,989,245 bytes |          skipped |
-|[B4x100] Apply real-world editing dataset 100 times (parseTime)           |         2,183 ms |         1,564 ms |          skipped |
-|[B4x100] Apply real-world editing dataset 100 times (memUsed)             |         352.9 MB |              0 B |          skipped |
+|N = 6000 | [yjs](https://github.com/yjs/yjs) | [ywasm](https://github.com/y-crdt/y-crdt/tree/main/ywasm) | [loro](https://github.com/loro-dev/loro) | [automerge](https://github.com/automerge/automerge/) |
+| :- |  -: | -: | -: | -:  |
+|Version                                                                   |          13.6.11 |            0.9.3 |           0.10.0 |           2.1.10 |
+|Bundle size                                                               |     80,413 bytes |    677,652 bytes |  1,059,834 bytes |  1,737,571 bytes |
+|Bundle size (gzipped)                                                     |     23,571 bytes |    213,832 bytes |    401,549 bytes |    604,118 bytes |
+|[B1.1] Append N characters (time)                                         |           164 ms |           135 ms |           126 ms |           364 ms |
+|[B1.1] Append N characters (avgUpdateSize)                                |         27 bytes |         27 bytes |        109 bytes |        121 bytes |
+|[B1.1] Append N characters (encodeTime)                                   |             1 ms |             1 ms |             0 ms |             7 ms |
+|[B1.1] Append N characters (docSize)                                      |      6,031 bytes |      6,031 bytes |      6,152 bytes |      3,992 bytes |
+|[B1.1] Append N characters (memUsed)                                      |              0 B |              0 B |              0 B |              0 B |
+|[B1.1] Append N characters (parseTime)                                    |            46 ms |            43 ms |            38 ms |            95 ms |
+|[B1.2] Insert string of length N (time)                                   |             1 ms |             0 ms |             0 ms |             9 ms |
+|[B1.2] Insert string of length N (avgUpdateSize)                          |      6,031 bytes |      6,031 bytes |      6,107 bytes |      6,201 bytes |
+|[B1.2] Insert string of length N (encodeTime)                             |             1 ms |             0 ms |             0 ms |             3 ms |
+|[B1.2] Insert string of length N (docSize)                                |      6,031 bytes |      6,031 bytes |      6,107 bytes |      3,974 bytes |
+|[B1.2] Insert string of length N (memUsed)                                |         192.4 kB |         424.3 kB |           132 kB |           9.2 kB |
+|[B1.2] Insert string of length N (parseTime)                              |            56 ms |            44 ms |            43 ms |            43 ms |
+|[B1.3] Prepend N characters (time)                                        |           132 ms |            21 ms |            85 ms |           314 ms |
+|[B1.3] Prepend N characters (avgUpdateSize)                               |         27 bytes |         27 bytes |        108 bytes |        116 bytes |
+|[B1.3] Prepend N characters (encodeTime)                                  |             3 ms |             0 ms |             2 ms |             5 ms |
+|[B1.3] Prepend N characters (docSize)                                     |      6,041 bytes |      6,041 bytes |     12,114 bytes |      3,988 bytes |
+|[B1.3] Prepend N characters (memUsed)                                     |           1.2 MB |           8.3 kB |              0 B |              0 B |
+|[B1.3] Prepend N characters (parseTime)                                   |            85 ms |            50 ms |            69 ms |            96 ms |
+|[B1.4] Insert N characters at random positions (time)                     |           145 ms |           130 ms |            84 ms |           314 ms |
+|[B1.4] Insert N characters at random positions (avgUpdateSize)            |         29 bytes |         29 bytes |        109 bytes |        121 bytes |
+|[B1.4] Insert N characters at random positions (encodeTime)               |             7 ms |             1 ms |             2 ms |             9 ms |
+|[B1.4] Insert N characters at random positions (docSize)                  |     29,554 bytes |     29,554 bytes |     23,527 bytes |     24,743 bytes |
+|[B1.4] Insert N characters at random positions (memUsed)                  |           1.1 MB |              0 B |              0 B |           9.5 kB |
+|[B1.4] Insert N characters at random positions (parseTime)                |            90 ms |            43 ms |            63 ms |           106 ms |
+|[B1.5] Insert N words at random positions (time)                          |           166 ms |           438 ms |            87 ms |           515 ms |
+|[B1.5] Insert N words at random positions (avgUpdateSize)                 |         36 bytes |         36 bytes |        117 bytes |        131 bytes |
+|[B1.5] Insert N words at random positions (encodeTime)                    |            10 ms |             1 ms |             2 ms |            23 ms |
+|[B1.5] Insert N words at random positions (docSize)                       |     87,924 bytes |     87,924 bytes |     62,296 bytes |     96,203 bytes |
+|[B1.5] Insert N words at random positions (memUsed)                       |           2.3 MB |            720 B |              0 B |              0 B |
+|[B1.5] Insert N words at random positions (parseTime)                     |            74 ms |            48 ms |            79 ms |           171 ms |
+|[B1.6] Insert string, then delete it (time)                               |             2 ms |             1 ms |             2 ms |            24 ms |
+|[B1.6] Insert string, then delete it (avgUpdateSize)                      |      6,053 bytes |      6,053 bytes |      6,217 bytes |      6,338 bytes |
+|[B1.6] Insert string, then delete it (encodeTime)                         |             0 ms |             0 ms |             0 ms |             4 ms |
+|[B1.6] Insert string, then delete it (docSize)                            |         38 bytes |         38 bytes |      6,114 bytes |      3,993 bytes |
+|[B1.6] Insert string, then delete it (memUsed)                            |          65.7 kB |              0 B |           2.6 kB |           2.2 kB |
+|[B1.6] Insert string, then delete it (parseTime)                          |            59 ms |            43 ms |            38 ms |            67 ms |
+|[B1.7] Insert/Delete strings at random positions (time)                   |           171 ms |           137 ms |           107 ms |           462 ms |
+|[B1.7] Insert/Delete strings at random positions (avgUpdateSize)          |         31 bytes |         31 bytes |        113 bytes |        135 bytes |
+|[B1.7] Insert/Delete strings at random positions (encodeTime)             |             8 ms |             1 ms |             2 ms |            21 ms |
+|[B1.7] Insert/Delete strings at random positions (docSize)                |     28,377 bytes |     28,377 bytes |     47,181 bytes |     59,281 bytes |
+|[B1.7] Insert/Delete strings at random positions (memUsed)                |           1.2 MB |            480 B |              0 B |              0 B |
+|[B1.7] Insert/Delete strings at random positions (parseTime)              |            93 ms |            46 ms |            74 ms |           136 ms |
+|[B1.8] Append N numbers (time)                                            |           160 ms |            26 ms |            89 ms |           455 ms |
+|[B1.8] Append N numbers (avgUpdateSize)                                   |         32 bytes |         32 bytes |        114 bytes |        125 bytes |
+|[B1.8] Append N numbers (encodeTime)                                      |             4 ms |             0 ms |             1 ms |            10 ms |
+|[B1.8] Append N numbers (docSize)                                         |     35,634 bytes |     35,634 bytes |     35,712 bytes |     26,985 bytes |
+|[B1.8] Append N numbers (memUsed)                                         |              0 B |              0 B |              0 B |          63.8 kB |
+|[B1.8] Append N numbers (parseTime)                                       |            66 ms |            43 ms |            38 ms |           101 ms |
+|[B1.9] Insert Array of N numbers (time)                                   |             5 ms |             3 ms |             7 ms |            40 ms |
+|[B1.9] Insert Array of N numbers (avgUpdateSize)                          |     35,657 bytes |     35,657 bytes |     35,735 bytes |     31,199 bytes |
+|[B1.9] Insert Array of N numbers (encodeTime)                             |             1 ms |             0 ms |             1 ms |             5 ms |
+|[B1.9] Insert Array of N numbers (docSize)                                |     35,657 bytes |     35,657 bytes |     35,735 bytes |     26,953 bytes |
+|[B1.9] Insert Array of N numbers (memUsed)                                |          45.6 kB |            552 B |           2.5 kB |          37.9 kB |
+|[B1.9] Insert Array of N numbers (parseTime)                              |            58 ms |            42 ms |            40 ms |            68 ms |
+|[B1.10] Prepend N numbers (time)                                          |           129 ms |            27 ms |            87 ms |           530 ms |
+|[B1.10] Prepend N numbers (avgUpdateSize)                                 |         32 bytes |         36 bytes |        113 bytes |        120 bytes |
+|[B1.10] Prepend N numbers (encodeTime)                                    |             6 ms |             1 ms |             2 ms |             8 ms |
+|[B1.10] Prepend N numbers (docSize)                                       |     35,665 bytes |     65,658 bytes |     41,740 bytes |     26,987 bytes |
+|[B1.10] Prepend N numbers (memUsed)                                       |           1.9 MB |              0 B |              0 B |          65.7 kB |
+|[B1.10] Prepend N numbers (parseTime)                                     |            73 ms |            45 ms |            59 ms |           106 ms |
+|[B1.11] Insert N numbers at random positions (time)                       |           144 ms |           149 ms |            78 ms |           470 ms |
+|[B1.11] Insert N numbers at random positions (avgUpdateSize)              |         34 bytes |         34 bytes |        114 bytes |        125 bytes |
+|[B1.11] Insert N numbers at random positions (encodeTime)                 |             8 ms |             1 ms |             6 ms |            11 ms |
+|[B1.11] Insert N numbers at random positions (docSize)                    |     59,137 bytes |     59,152 bytes |     53,145 bytes |     47,746 bytes |
+|[B1.11] Insert N numbers at random positions (memUsed)                    |           2.1 MB |              0 B |              0 B |          60.1 kB |
+|[B1.11] Insert N numbers at random positions (parseTime)                  |            93 ms |            51 ms |            74 ms |           104 ms |
+|[B2.1] Concurrently insert string of length N at index 0 (time)           |             3 ms |             0 ms |             1 ms |            71 ms |
+|[B2.1] Concurrently insert string of length N at index 0 (updateSize)     |      6,093 bytes |      6,094 bytes |      6,218 bytes |      9,499 bytes |
+|[B2.1] Concurrently insert string of length N at index 0 (encodeTime)     |             0 ms |             0 ms |             0 ms |             6 ms |
+|[B2.1] Concurrently insert string of length N at index 0 (docSize)        |     12,150 bytes |     12,152 bytes |     12,237 bytes |      8,011 bytes |
+|[B2.1] Concurrently insert string of length N at index 0 (memUsed)        |          76.2 kB |            304 B |           1.8 kB |          14.5 kB |
+|[B2.1] Concurrently insert string of length N at index 0 (parseTime)      |            62 ms |            41 ms |            39 ms |            64 ms |
+|[B2.2] Concurrently insert N characters at random positions (time)        |            72 ms |           405 ms |            78 ms |           311 ms |
+|[B2.2] Concurrently insert N characters at random positions (updateSize)  |     33,444 bytes |    177,007 bytes |     23,735 bytes |     27,476 bytes |
+|[B2.2] Concurrently insert N characters at random positions (encodeTime)  |             2 ms |             1 ms |             3 ms |            10 ms |
+|[B2.2] Concurrently insert N characters at random positions (docSize)     |     66,860 bytes |     66,852 bytes |     47,273 bytes |     50,683 bytes |
+|[B2.2] Concurrently insert N characters at random positions (memUsed)     |           2.4 MB |            480 B |              0 B |              0 B |
+|[B2.2] Concurrently insert N characters at random positions (parseTime)   |            65 ms |            52 ms |            91 ms |            67 ms |
+|[B2.3] Concurrently insert N words at random positions (time)             |            86 ms |         1,046 ms |           110 ms |           701 ms |
+|[B2.3] Concurrently insert N words at random positions (updateSize)       |     88,994 bytes |    215,213 bytes |     62,098 bytes |    122,485 bytes |
+|[B2.3] Concurrently insert N words at random positions (encodeTime)       |             4 ms |             4 ms |             3 ms |            37 ms |
+|[B2.3] Concurrently insert N words at random positions (docSize)          |    178,137 bytes |    178,137 bytes |    123,997 bytes |    185,019 bytes |
+|[B2.3] Concurrently insert N words at random positions (memUsed)          |           5.6 MB |            432 B |              0 B |              0 B |
+|[B2.3] Concurrently insert N words at random positions (parseTime)        |            76 ms |            73 ms |           138 ms |           190 ms |
+|[B2.4] Concurrently insert & delete (time)                                |           232 ms |         2,740 ms |           205 ms |         1,113 ms |
+|[B2.4] Concurrently insert & delete (updateSize)                          |    139,517 bytes |    398,881 bytes |    109,161 bytes |    298,810 bytes |
+|[B2.4] Concurrently insert & delete (encodeTime)                          |            21 ms |             7 ms |             9 ms |            62 ms |
+|[B2.4] Concurrently insert & delete (docSize)                             |    279,172 bytes |    279,172 bytes |    218,118 bytes |    293,829 bytes |
+|[B2.4] Concurrently insert & delete (memUsed)                             |           9.4 MB |            432 B |              0 B |              0 B |
+|[B2.4] Concurrently insert & delete (parseTime)                           |           142 ms |            84 ms |           204 ms |           278 ms |
+|[B3.1] 20√N clients concurrently set number in Map (time)                 |            91 ms |           276 ms |         1,891 ms |         1,616 ms |
+|[B3.1] 20√N clients concurrently set number in Map (updateSize)           |     49,181 bytes |     49,169 bytes |    161,636 bytes |    283,296 bytes |
+|[B3.1] 20√N clients concurrently set number in Map (encodeTime)           |             4 ms |             2 ms |             1 ms |            12 ms |
+|[B3.1] 20√N clients concurrently set number in Map (docSize)              |     32,246 bytes |     32,213 bytes |     21,487 bytes |     86,170 bytes |
+|[B3.1] 20√N clients concurrently set number in Map (memUsed)              |         196.3 kB |            272 B |            144 B |              0 B |
+|[B3.1] 20√N clients concurrently set number in Map (parseTime)            |           100 ms |            77 ms |            44 ms |            48 ms |
+|[B3.2] 20√N clients concurrently set Object in Map (time)                 |            84 ms |           284 ms |         2,030 ms |         1,727 ms |
+|[B3.2] 20√N clients concurrently set Object in Map (updateSize)           |     85,082 bytes |     85,069 bytes |    200,630 bytes |    398,090 bytes |
+|[B3.2] 20√N clients concurrently set Object in Map (encodeTime)           |             4 ms |             2 ms |             3 ms |            32 ms |
+|[B3.2] 20√N clients concurrently set Object in Map (docSize)              |     32,241 bytes |     32,218 bytes |     40,475 bytes |    112,588 bytes |
+|[B3.2] 20√N clients concurrently set Object in Map (memUsed)              |         232.4 kB |              0 B |            312 B |              0 B |
+|[B3.2] 20√N clients concurrently set Object in Map (parseTime)            |            93 ms |            75 ms |            96 ms |            93 ms |
+|[B3.3] 20√N clients concurrently set String in Map (time)                 |            88 ms |           299 ms |         2,037 ms |         2,644 ms |
+|[B3.3] 20√N clients concurrently set String in Map (updateSize)           |  7,826,225 bytes |  7,826,232 bytes |  7,940,240 bytes |  8,063,440 bytes |
+|[B3.3] 20√N clients concurrently set String in Map (encodeTime)           |             4 ms |             1 ms |            45 ms |           105 ms |
+|[B3.3] 20√N clients concurrently set String in Map (docSize)              |     38,370 bytes |     35,296 bytes |  7,799,167 bytes |     98,003 bytes |
+|[B3.3] 20√N clients concurrently set String in Map (memUsed)              |         179.2 kB |            200 B |            656 B |              0 B |
+|[B3.3] 20√N clients concurrently set String in Map (parseTime)            |           104 ms |            86 ms |            74 ms |           130 ms |
+|[B3.4] 20√N clients concurrently insert text in Array (time)              |            75 ms |           283 ms |       107,643 ms |         2,726 ms |
+|[B3.4] 20√N clients concurrently insert text in Array (updateSize)        |     52,743 bytes |     52,740 bytes |    166,750 bytes |    311,830 bytes |
+|[B3.4] 20√N clients concurrently insert text in Array (encodeTime)        |             2 ms |             1 ms |             2 ms |            18 ms |
+|[B3.4] 20√N clients concurrently insert text in Array (docSize)           |     26,588 bytes |     26,585 bytes |     28,140 bytes |     96,446 bytes |
+|[B3.4] 20√N clients concurrently insert text in Array (memUsed)           |         720.9 kB |           5.5 kB |           6.1 kB |          38.2 kB |
+|[B3.4] 20√N clients concurrently insert text in Array (parseTime)         |            76 ms |            76 ms |           254 ms |            59 ms |
+|[B4] Apply real-world editing dataset (time)                              |         1,803 ms |        43,943 ms |         1,198 ms |        12,746 ms |
+|[B4] Apply real-world editing dataset (encodeTime)                        |            12 ms |             4 ms |             7 ms |           219 ms |
+|[B4] Apply real-world editing dataset (docSize)                           |    159,929 bytes |    159,929 bytes |    229,732 bytes |    129,116 bytes |
+|[B4] Apply real-world editing dataset (parseTime)                         |            38 ms |            17 ms |            74 ms |         2,115 ms |
+|[B4] Apply real-world editing dataset (memUsed)                           |           3.5 MB |            856 B |              0 B |         139.6 kB |
+|[B4x100] Apply real-world editing dataset 100 times (time)                |       199,319 ms |     2,732,719 ms |          skipped |          skipped |
+|[B4x100] Apply real-world editing dataset 100 times (encodeTime)          |           388 ms |           209 ms |          skipped |          skipped |
+|[B4x100] Apply real-world editing dataset 100 times (docSize)             | 15,989,245 bytes | 15,989,245 bytes |          skipped |          skipped |
+|[B4x100] Apply real-world editing dataset 100 times (parseTime)           |         2,183 ms |         1,564 ms |          skipped |          skipped |
+|[B4x100] Apply real-world editing dataset 100 times (memUsed)             |         352.9 MB |              0 B |          skipped |          skipped |
 
 ##### Older benchmark results that include automerge & delta-crdts
 

--- a/README.md
+++ b/README.md
@@ -95,133 +95,133 @@ this feature by default. You can disable/enable this feature in
 
 |N = 6000 | [yjs](https://github.com/yjs/yjs) | [ywasm](https://github.com/y-crdt/y-crdt/tree/main/ywasm) | [loro](https://github.com/loro-dev/loro) | [automerge](https://github.com/automerge/automerge/) |
 | :- |  -: | -: | -: | -:  |
-|Version                                                                   |          13.6.11 |            0.9.3 |           0.10.0 |           2.1.10 |
-|Bundle size                                                               |     80,413 bytes |    677,652 bytes |  1,059,834 bytes |  1,737,571 bytes |
-|Bundle size (gzipped)                                                     |     23,571 bytes |    213,832 bytes |    401,549 bytes |    604,118 bytes |
-|[B1.1] Append N characters (time)                                         |           164 ms |           135 ms |           126 ms |           364 ms |
+|Version                                                                   |          13.6.11 |            0.9.3 |           0.10.1 |           2.1.10 |
+|Bundle size                                                               |     53,755 bytes |    677,667 bytes |  1,052,250 bytes |  1,737,571 bytes |
+|Bundle size (gzipped)                                                     |     38,816 bytes |    213,833 bytes |    399,276 bytes |    604,118 bytes |
+|[B1.1] Append N characters (time)                                         |           188 ms |           154 ms |           120 ms |           365 ms |
 |[B1.1] Append N characters (avgUpdateSize)                                |         27 bytes |         27 bytes |        109 bytes |        121 bytes |
-|[B1.1] Append N characters (encodeTime)                                   |             1 ms |             1 ms |             0 ms |             7 ms |
-|[B1.1] Append N characters (docSize)                                      |      6,031 bytes |      6,031 bytes |      6,152 bytes |      3,992 bytes |
+|[B1.1] Append N characters (encodeTime)                                   |             1 ms |             1 ms |             1 ms |             7 ms |
+|[B1.1] Append N characters (docSize)                                      |      6,031 bytes |      6,031 bytes |      6,162 bytes |      3,992 bytes |
 |[B1.1] Append N characters (memUsed)                                      |              0 B |              0 B |              0 B |              0 B |
-|[B1.1] Append N characters (parseTime)                                    |            46 ms |            43 ms |            38 ms |            95 ms |
-|[B1.2] Insert string of length N (time)                                   |             1 ms |             0 ms |             0 ms |             9 ms |
+|[B1.1] Append N characters (parseTime)                                    |            32 ms |            23 ms |            26 ms |            80 ms |
+|[B1.2] Insert string of length N (time)                                   |             0 ms |             0 ms |             0 ms |             9 ms |
 |[B1.2] Insert string of length N (avgUpdateSize)                          |      6,031 bytes |      6,031 bytes |      6,107 bytes |      6,201 bytes |
-|[B1.2] Insert string of length N (encodeTime)                             |             1 ms |             0 ms |             0 ms |             3 ms |
-|[B1.2] Insert string of length N (docSize)                                |      6,031 bytes |      6,031 bytes |      6,107 bytes |      3,974 bytes |
-|[B1.2] Insert string of length N (memUsed)                                |         192.4 kB |         424.3 kB |           132 kB |           9.2 kB |
-|[B1.2] Insert string of length N (parseTime)                              |            56 ms |            44 ms |            43 ms |            43 ms |
-|[B1.3] Prepend N characters (time)                                        |           132 ms |            21 ms |            85 ms |           314 ms |
+|[B1.2] Insert string of length N (encodeTime)                             |             0 ms |             0 ms |             0 ms |             3 ms |
+|[B1.2] Insert string of length N (docSize)                                |      6,031 bytes |      6,031 bytes |      6,117 bytes |      3,974 bytes |
+|[B1.2] Insert string of length N (memUsed)                                |          17.4 kB |              0 B |              0 B |           8.8 kB |
+|[B1.2] Insert string of length N (parseTime)                              |            27 ms |            34 ms |            29 ms |            47 ms |
+|[B1.3] Prepend N characters (time)                                        |           119 ms |            23 ms |            81 ms |           307 ms |
 |[B1.3] Prepend N characters (avgUpdateSize)                               |         27 bytes |         27 bytes |        108 bytes |        116 bytes |
-|[B1.3] Prepend N characters (encodeTime)                                  |             3 ms |             0 ms |             2 ms |             5 ms |
-|[B1.3] Prepend N characters (docSize)                                     |      6,041 bytes |      6,041 bytes |     12,114 bytes |      3,988 bytes |
-|[B1.3] Prepend N characters (memUsed)                                     |           1.2 MB |           8.3 kB |              0 B |              0 B |
-|[B1.3] Prepend N characters (parseTime)                                   |            85 ms |            50 ms |            69 ms |            96 ms |
-|[B1.4] Insert N characters at random positions (time)                     |           145 ms |           130 ms |            84 ms |           314 ms |
+|[B1.3] Prepend N characters (encodeTime)                                  |             3 ms |             0 ms |            10 ms |             5 ms |
+|[B1.3] Prepend N characters (docSize)                                     |      6,041 bytes |      6,041 bytes |     12,125 bytes |      3,988 bytes |
+|[B1.3] Prepend N characters (memUsed)                                     |         919.9 kB |           8.3 kB |          26.3 kB |              0 B |
+|[B1.3] Prepend N characters (parseTime)                                   |            93 ms |            31 ms |            26 ms |            63 ms |
+|[B1.4] Insert N characters at random positions (time)                     |           131 ms |           128 ms |            79 ms |           310 ms |
 |[B1.4] Insert N characters at random positions (avgUpdateSize)            |         29 bytes |         29 bytes |        109 bytes |        121 bytes |
-|[B1.4] Insert N characters at random positions (encodeTime)               |             7 ms |             1 ms |             2 ms |             9 ms |
-|[B1.4] Insert N characters at random positions (docSize)                  |     29,554 bytes |     29,554 bytes |     23,527 bytes |     24,743 bytes |
-|[B1.4] Insert N characters at random positions (memUsed)                  |           1.1 MB |              0 B |              0 B |           9.5 kB |
-|[B1.4] Insert N characters at random positions (parseTime)                |            90 ms |            43 ms |            63 ms |           106 ms |
-|[B1.5] Insert N words at random positions (time)                          |           166 ms |           438 ms |            87 ms |           515 ms |
+|[B1.4] Insert N characters at random positions (encodeTime)               |             1 ms |             1 ms |            35 ms |             8 ms |
+|[B1.4] Insert N characters at random positions (docSize)                  |     29,554 bytes |     29,554 bytes |     35,401 bytes |     24,743 bytes |
+|[B1.4] Insert N characters at random positions (memUsed)                  |         883.6 kB |              0 B |              0 B |             9 kB |
+|[B1.4] Insert N characters at random positions (parseTime)                |            76 ms |            29 ms |            31 ms |            79 ms |
+|[B1.5] Insert N words at random positions (time)                          |           154 ms |           449 ms |            82 ms |           449 ms |
 |[B1.5] Insert N words at random positions (avgUpdateSize)                 |         36 bytes |         36 bytes |        117 bytes |        131 bytes |
-|[B1.5] Insert N words at random positions (encodeTime)                    |            10 ms |             1 ms |             2 ms |            23 ms |
-|[B1.5] Insert N words at random positions (docSize)                       |     87,924 bytes |     87,924 bytes |     62,296 bytes |     96,203 bytes |
-|[B1.5] Insert N words at random positions (memUsed)                       |           2.3 MB |            720 B |              0 B |              0 B |
-|[B1.5] Insert N words at random positions (parseTime)                     |            74 ms |            48 ms |            79 ms |           171 ms |
-|[B1.6] Insert string, then delete it (time)                               |             2 ms |             1 ms |             2 ms |            24 ms |
+|[B1.5] Insert N words at random positions (encodeTime)                    |             5 ms |             1 ms |            69 ms |            21 ms |
+|[B1.5] Insert N words at random positions (docSize)                       |     87,924 bytes |     87,924 bytes |     94,524 bytes |     96,203 bytes |
+|[B1.5] Insert N words at random positions (memUsed)                       |           2.3 MB |            872 B |           2.1 kB |              0 B |
+|[B1.5] Insert N words at random positions (parseTime)                     |            92 ms |            34 ms |            31 ms |           143 ms |
+|[B1.6] Insert string, then delete it (time)                               |             1 ms |             1 ms |             2 ms |            22 ms |
 |[B1.6] Insert string, then delete it (avgUpdateSize)                      |      6,053 bytes |      6,053 bytes |      6,217 bytes |      6,338 bytes |
-|[B1.6] Insert string, then delete it (encodeTime)                         |             0 ms |             0 ms |             0 ms |             4 ms |
-|[B1.6] Insert string, then delete it (docSize)                            |         38 bytes |         38 bytes |      6,114 bytes |      3,993 bytes |
-|[B1.6] Insert string, then delete it (memUsed)                            |          65.7 kB |              0 B |           2.6 kB |           2.2 kB |
-|[B1.6] Insert string, then delete it (parseTime)                          |            59 ms |            43 ms |            38 ms |            67 ms |
-|[B1.7] Insert/Delete strings at random positions (time)                   |           171 ms |           137 ms |           107 ms |           462 ms |
+|[B1.6] Insert string, then delete it (encodeTime)                         |             0 ms |             0 ms |             0 ms |             3 ms |
+|[B1.6] Insert string, then delete it (docSize)                            |         38 bytes |         38 bytes |      6,120 bytes |      3,993 bytes |
+|[B1.6] Insert string, then delete it (memUsed)                            |              0 B |              0 B |              0 B |             2 kB |
+|[B1.6] Insert string, then delete it (parseTime)                          |            44 ms |            28 ms |            27 ms |            37 ms |
+|[B1.7] Insert/Delete strings at random positions (time)                   |           158 ms |           141 ms |            98 ms |           389 ms |
 |[B1.7] Insert/Delete strings at random positions (avgUpdateSize)          |         31 bytes |         31 bytes |        113 bytes |        135 bytes |
-|[B1.7] Insert/Delete strings at random positions (encodeTime)             |             8 ms |             1 ms |             2 ms |            21 ms |
-|[B1.7] Insert/Delete strings at random positions (docSize)                |     28,377 bytes |     28,377 bytes |     47,181 bytes |     59,281 bytes |
-|[B1.7] Insert/Delete strings at random positions (memUsed)                |           1.2 MB |            480 B |              0 B |              0 B |
-|[B1.7] Insert/Delete strings at random positions (parseTime)              |            93 ms |            46 ms |            74 ms |           136 ms |
-|[B1.8] Append N numbers (time)                                            |           160 ms |            26 ms |            89 ms |           455 ms |
+|[B1.7] Insert/Delete strings at random positions (encodeTime)             |             8 ms |             1 ms |            17 ms |            19 ms |
+|[B1.7] Insert/Delete strings at random positions (docSize)                |     28,377 bytes |     28,377 bytes |     50,836 bytes |     59,281 bytes |
+|[B1.7] Insert/Delete strings at random positions (memUsed)                |           1.4 MB |            632 B |           1.8 kB |             6 kB |
+|[B1.7] Insert/Delete strings at random positions (parseTime)              |           117 ms |            31 ms |            25 ms |           111 ms |
+|[B1.8] Append N numbers (time)                                            |           148 ms |            29 ms |            81 ms |           480 ms |
 |[B1.8] Append N numbers (avgUpdateSize)                                   |         32 bytes |         32 bytes |        114 bytes |        125 bytes |
-|[B1.8] Append N numbers (encodeTime)                                      |             4 ms |             0 ms |             1 ms |            10 ms |
-|[B1.8] Append N numbers (docSize)                                         |     35,634 bytes |     35,634 bytes |     35,712 bytes |     26,985 bytes |
-|[B1.8] Append N numbers (memUsed)                                         |              0 B |              0 B |              0 B |          63.8 kB |
-|[B1.8] Append N numbers (parseTime)                                       |            66 ms |            43 ms |            38 ms |           101 ms |
-|[B1.9] Insert Array of N numbers (time)                                   |             5 ms |             3 ms |             7 ms |            40 ms |
+|[B1.8] Append N numbers (encodeTime)                                      |             0 ms |             0 ms |             1 ms |             8 ms |
+|[B1.8] Append N numbers (docSize)                                         |     35,634 bytes |     35,634 bytes |     35,719 bytes |     26,985 bytes |
+|[B1.8] Append N numbers (memUsed)                                         |              0 B |              0 B |              0 B |          61.3 kB |
+|[B1.8] Append N numbers (parseTime)                                       |            36 ms |            31 ms |            27 ms |            80 ms |
+|[B1.9] Insert Array of N numbers (time)                                   |             1 ms |             2 ms |             9 ms |            38 ms |
 |[B1.9] Insert Array of N numbers (avgUpdateSize)                          |     35,657 bytes |     35,657 bytes |     35,735 bytes |     31,199 bytes |
 |[B1.9] Insert Array of N numbers (encodeTime)                             |             1 ms |             0 ms |             1 ms |             5 ms |
-|[B1.9] Insert Array of N numbers (docSize)                                |     35,657 bytes |     35,657 bytes |     35,735 bytes |     26,953 bytes |
-|[B1.9] Insert Array of N numbers (memUsed)                                |          45.6 kB |            552 B |           2.5 kB |          37.9 kB |
-|[B1.9] Insert Array of N numbers (parseTime)                              |            58 ms |            42 ms |            40 ms |            68 ms |
-|[B1.10] Prepend N numbers (time)                                          |           129 ms |            27 ms |            87 ms |           530 ms |
+|[B1.9] Insert Array of N numbers (docSize)                                |     35,657 bytes |     35,657 bytes |     35,742 bytes |     26,953 bytes |
+|[B1.9] Insert Array of N numbers (memUsed)                                |          39.3 kB |            608 B |           2.4 kB |          61.6 kB |
+|[B1.9] Insert Array of N numbers (parseTime)                              |            33 ms |            26 ms |            22 ms |            53 ms |
+|[B1.10] Prepend N numbers (time)                                          |           122 ms |            28 ms |            78 ms |           461 ms |
 |[B1.10] Prepend N numbers (avgUpdateSize)                                 |         32 bytes |         36 bytes |        113 bytes |        120 bytes |
-|[B1.10] Prepend N numbers (encodeTime)                                    |             6 ms |             1 ms |             2 ms |             8 ms |
-|[B1.10] Prepend N numbers (docSize)                                       |     35,665 bytes |     65,658 bytes |     41,740 bytes |     26,987 bytes |
-|[B1.10] Prepend N numbers (memUsed)                                       |           1.9 MB |              0 B |              0 B |          65.7 kB |
-|[B1.10] Prepend N numbers (parseTime)                                     |            73 ms |            45 ms |            59 ms |           106 ms |
-|[B1.11] Insert N numbers at random positions (time)                       |           144 ms |           149 ms |            78 ms |           470 ms |
-|[B1.11] Insert N numbers at random positions (avgUpdateSize)              |         34 bytes |         34 bytes |        114 bytes |        125 bytes |
-|[B1.11] Insert N numbers at random positions (encodeTime)                 |             8 ms |             1 ms |             6 ms |            11 ms |
-|[B1.11] Insert N numbers at random positions (docSize)                    |     59,137 bytes |     59,152 bytes |     53,145 bytes |     47,746 bytes |
-|[B1.11] Insert N numbers at random positions (memUsed)                    |           2.1 MB |              0 B |              0 B |          60.1 kB |
-|[B1.11] Insert N numbers at random positions (parseTime)                  |            93 ms |            51 ms |            74 ms |           104 ms |
-|[B2.1] Concurrently insert string of length N at index 0 (time)           |             3 ms |             0 ms |             1 ms |            71 ms |
-|[B2.1] Concurrently insert string of length N at index 0 (updateSize)     |      6,093 bytes |      6,094 bytes |      6,218 bytes |      9,499 bytes |
-|[B2.1] Concurrently insert string of length N at index 0 (encodeTime)     |             0 ms |             0 ms |             0 ms |             6 ms |
-|[B2.1] Concurrently insert string of length N at index 0 (docSize)        |     12,150 bytes |     12,152 bytes |     12,237 bytes |      8,011 bytes |
-|[B2.1] Concurrently insert string of length N at index 0 (memUsed)        |          76.2 kB |            304 B |           1.8 kB |          14.5 kB |
-|[B2.1] Concurrently insert string of length N at index 0 (parseTime)      |            62 ms |            41 ms |            39 ms |            64 ms |
-|[B2.2] Concurrently insert N characters at random positions (time)        |            72 ms |           405 ms |            78 ms |           311 ms |
-|[B2.2] Concurrently insert N characters at random positions (updateSize)  |     33,444 bytes |    177,007 bytes |     23,735 bytes |     27,476 bytes |
-|[B2.2] Concurrently insert N characters at random positions (encodeTime)  |             2 ms |             1 ms |             3 ms |            10 ms |
-|[B2.2] Concurrently insert N characters at random positions (docSize)     |     66,860 bytes |     66,852 bytes |     47,273 bytes |     50,683 bytes |
-|[B2.2] Concurrently insert N characters at random positions (memUsed)     |           2.4 MB |            480 B |              0 B |              0 B |
-|[B2.2] Concurrently insert N characters at random positions (parseTime)   |            65 ms |            52 ms |            91 ms |            67 ms |
-|[B2.3] Concurrently insert N words at random positions (time)             |            86 ms |         1,046 ms |           110 ms |           701 ms |
-|[B2.3] Concurrently insert N words at random positions (updateSize)       |     88,994 bytes |    215,213 bytes |     62,098 bytes |    122,485 bytes |
-|[B2.3] Concurrently insert N words at random positions (encodeTime)       |             4 ms |             4 ms |             3 ms |            37 ms |
-|[B2.3] Concurrently insert N words at random positions (docSize)          |    178,137 bytes |    178,137 bytes |    123,997 bytes |    185,019 bytes |
-|[B2.3] Concurrently insert N words at random positions (memUsed)          |           5.6 MB |            432 B |              0 B |              0 B |
-|[B2.3] Concurrently insert N words at random positions (parseTime)        |            76 ms |            73 ms |           138 ms |           190 ms |
-|[B2.4] Concurrently insert & delete (time)                                |           232 ms |         2,740 ms |           205 ms |         1,113 ms |
-|[B2.4] Concurrently insert & delete (updateSize)                          |    139,517 bytes |    398,881 bytes |    109,161 bytes |    298,810 bytes |
-|[B2.4] Concurrently insert & delete (encodeTime)                          |            21 ms |             7 ms |             9 ms |            62 ms |
-|[B2.4] Concurrently insert & delete (docSize)                             |    279,172 bytes |    279,172 bytes |    218,118 bytes |    293,829 bytes |
-|[B2.4] Concurrently insert & delete (memUsed)                             |           9.4 MB |            432 B |              0 B |              0 B |
-|[B2.4] Concurrently insert & delete (parseTime)                           |           142 ms |            84 ms |           204 ms |           278 ms |
-|[B3.1] 20√N clients concurrently set number in Map (time)                 |            91 ms |           276 ms |         1,891 ms |         1,616 ms |
-|[B3.1] 20√N clients concurrently set number in Map (updateSize)           |     49,181 bytes |     49,169 bytes |    161,636 bytes |    283,296 bytes |
-|[B3.1] 20√N clients concurrently set number in Map (encodeTime)           |             4 ms |             2 ms |             1 ms |            12 ms |
-|[B3.1] 20√N clients concurrently set number in Map (docSize)              |     32,246 bytes |     32,213 bytes |     21,487 bytes |     86,170 bytes |
-|[B3.1] 20√N clients concurrently set number in Map (memUsed)              |         196.3 kB |            272 B |            144 B |              0 B |
-|[B3.1] 20√N clients concurrently set number in Map (parseTime)            |           100 ms |            77 ms |            44 ms |            48 ms |
-|[B3.2] 20√N clients concurrently set Object in Map (time)                 |            84 ms |           284 ms |         2,030 ms |         1,727 ms |
-|[B3.2] 20√N clients concurrently set Object in Map (updateSize)           |     85,082 bytes |     85,069 bytes |    200,630 bytes |    398,090 bytes |
-|[B3.2] 20√N clients concurrently set Object in Map (encodeTime)           |             4 ms |             2 ms |             3 ms |            32 ms |
-|[B3.2] 20√N clients concurrently set Object in Map (docSize)              |     32,241 bytes |     32,218 bytes |     40,475 bytes |    112,588 bytes |
-|[B3.2] 20√N clients concurrently set Object in Map (memUsed)              |         232.4 kB |              0 B |            312 B |              0 B |
-|[B3.2] 20√N clients concurrently set Object in Map (parseTime)            |            93 ms |            75 ms |            96 ms |            93 ms |
-|[B3.3] 20√N clients concurrently set String in Map (time)                 |            88 ms |           299 ms |         2,037 ms |         2,644 ms |
-|[B3.3] 20√N clients concurrently set String in Map (updateSize)           |  7,826,225 bytes |  7,826,232 bytes |  7,940,240 bytes |  8,063,440 bytes |
-|[B3.3] 20√N clients concurrently set String in Map (encodeTime)           |             4 ms |             1 ms |            45 ms |           105 ms |
-|[B3.3] 20√N clients concurrently set String in Map (docSize)              |     38,370 bytes |     35,296 bytes |  7,799,167 bytes |     98,003 bytes |
-|[B3.3] 20√N clients concurrently set String in Map (memUsed)              |         179.2 kB |            200 B |            656 B |              0 B |
-|[B3.3] 20√N clients concurrently set String in Map (parseTime)            |           104 ms |            86 ms |            74 ms |           130 ms |
-|[B3.4] 20√N clients concurrently insert text in Array (time)              |            75 ms |           283 ms |       107,643 ms |         2,726 ms |
-|[B3.4] 20√N clients concurrently insert text in Array (updateSize)        |     52,743 bytes |     52,740 bytes |    166,750 bytes |    311,830 bytes |
-|[B3.4] 20√N clients concurrently insert text in Array (encodeTime)        |             2 ms |             1 ms |             2 ms |            18 ms |
-|[B3.4] 20√N clients concurrently insert text in Array (docSize)           |     26,588 bytes |     26,585 bytes |     28,140 bytes |     96,446 bytes |
-|[B3.4] 20√N clients concurrently insert text in Array (memUsed)           |         720.9 kB |           5.5 kB |           6.1 kB |          38.2 kB |
-|[B3.4] 20√N clients concurrently insert text in Array (parseTime)         |            76 ms |            76 ms |           254 ms |            59 ms |
-|[B4] Apply real-world editing dataset (time)                              |         1,803 ms |        43,943 ms |         1,198 ms |        12,746 ms |
-|[B4] Apply real-world editing dataset (encodeTime)                        |            12 ms |             4 ms |             7 ms |           219 ms |
-|[B4] Apply real-world editing dataset (docSize)                           |    159,929 bytes |    159,929 bytes |    229,732 bytes |    129,116 bytes |
-|[B4] Apply real-world editing dataset (parseTime)                         |            38 ms |            17 ms |            74 ms |         2,115 ms |
-|[B4] Apply real-world editing dataset (memUsed)                           |           3.5 MB |            856 B |              0 B |         139.6 kB |
-|[B4x100] Apply real-world editing dataset 100 times (time)                |       199,319 ms |     2,732,719 ms |          skipped |          skipped |
-|[B4x100] Apply real-world editing dataset 100 times (encodeTime)          |           388 ms |           209 ms |          skipped |          skipped |
-|[B4x100] Apply real-world editing dataset 100 times (docSize)             | 15,989,245 bytes | 15,989,245 bytes |          skipped |          skipped |
-|[B4x100] Apply real-world editing dataset 100 times (parseTime)           |         2,183 ms |         1,564 ms |          skipped |          skipped |
-|[B4x100] Apply real-world editing dataset 100 times (memUsed)             |         352.9 MB |              0 B |          skipped |          skipped |
+|[B1.10] Prepend N numbers (encodeTime)                                    |             3 ms |             1 ms |            10 ms |             7 ms |
+|[B1.10] Prepend N numbers (docSize)                                       |     35,665 bytes |     65,658 bytes |     41,748 bytes |     26,987 bytes |
+|[B1.10] Prepend N numbers (memUsed)                                       |           1.8 MB |           168 kB |         119.5 kB |          61.5 kB |
+|[B1.10] Prepend N numbers (parseTime)                                     |            96 ms |            31 ms |            32 ms |            77 ms |
+|[B1.11] Insert N numbers at random positions (time)                       |           134 ms |           144 ms |            78 ms |           433 ms |
+|[B1.11] Insert N numbers at random positions (avgUpdateSize)              |         33 bytes |         34 bytes |        114 bytes |        125 bytes |
+|[B1.11] Insert N numbers at random positions (encodeTime)                 |             1 ms |             1 ms |            37 ms |             9 ms |
+|[B1.11] Insert N numbers at random positions (docSize)                    |     59,136 bytes |     59,152 bytes |     65,016 bytes |     47,746 bytes |
+|[B1.11] Insert N numbers at random positions (memUsed)                    |           1.8 MB |              0 B |              0 B |          61.7 kB |
+|[B1.11] Insert N numbers at random positions (parseTime)                  |            80 ms |            34 ms |            36 ms |            93 ms |
+|[B2.1] Concurrently insert string of length N at index 0 (time)           |             1 ms |             0 ms |             2 ms |            62 ms |
+|[B2.1] Concurrently insert string of length N at index 0 (updateSize)     |      6,094 bytes |      6,094 bytes |      9,276 bytes |      9,499 bytes |
+|[B2.1] Concurrently insert string of length N at index 0 (encodeTime)     |             0 ms |             0 ms |             0 ms |             5 ms |
+|[B2.1] Concurrently insert string of length N at index 0 (docSize)        |     12,152 bytes |     12,151 bytes |     12,248 bytes |      8,011 bytes |
+|[B2.1] Concurrently insert string of length N at index 0 (memUsed)        |              0 B |            592 B |           6.4 kB |          14.5 kB |
+|[B2.1] Concurrently insert string of length N at index 0 (parseTime)      |            43 ms |            27 ms |            25 ms |            47 ms |
+|[B2.2] Concurrently insert N characters at random positions (time)        |            65 ms |           365 ms |            83 ms |           287 ms |
+|[B2.2] Concurrently insert N characters at random positions (updateSize)  |     33,444 bytes |    177,007 bytes |     35,554 bytes |     27,476 bytes |
+|[B2.2] Concurrently insert N characters at random positions (encodeTime)  |             2 ms |             1 ms |            82 ms |             9 ms |
+|[B2.2] Concurrently insert N characters at random positions (docSize)     |     66,852 bytes |     66,860 bytes |     71,858 bytes |     50,683 bytes |
+|[B2.2] Concurrently insert N characters at random positions (memUsed)     |           2.4 MB |            392 B |           1.8 kB |              0 B |
+|[B2.2] Concurrently insert N characters at random positions (parseTime)   |           101 ms |            34 ms |            30 ms |            53 ms |
+|[B2.3] Concurrently insert N words at random positions (time)             |            85 ms |         1,014 ms |           112 ms |           663 ms |
+|[B2.3] Concurrently insert N words at random positions (updateSize)       |     88,994 bytes |    215,213 bytes |     93,132 bytes |    122,485 bytes |
+|[B2.3] Concurrently insert N words at random positions (encodeTime)       |             4 ms |             4 ms |           145 ms |            38 ms |
+|[B2.3] Concurrently insert N words at random positions (docSize)          |    178,137 bytes |    178,130 bytes |    188,458 bytes |    185,019 bytes |
+|[B2.3] Concurrently insert N words at random positions (memUsed)          |           5.5 MB |              0 B |           1.5 kB |              0 B |
+|[B2.3] Concurrently insert N words at random positions (parseTime)        |            85 ms |            71 ms |            52 ms |           168 ms |
+|[B2.4] Concurrently insert & delete (time)                                |           178 ms |         2,786 ms |           208 ms |         1,066 ms |
+|[B2.4] Concurrently insert & delete (updateSize)                          |    139,517 bytes |    398,881 bytes |    163,564 bytes |    298,810 bytes |
+|[B2.4] Concurrently insert & delete (encodeTime)                          |            12 ms |             6 ms |           233 ms |            62 ms |
+|[B2.4] Concurrently insert & delete (docSize)                             |    279,172 bytes |    279,166 bytes |    289,590 bytes |    293,828 bytes |
+|[B2.4] Concurrently insert & delete (memUsed)                             |           8.2 MB |              0 B |           1.8 kB |              0 B |
+|[B2.4] Concurrently insert & delete (parseTime)                           |           121 ms |            78 ms |            50 ms |           255 ms |
+|[B3.1] 20√N clients concurrently set number in Map (time)                 |            75 ms |           290 ms |            56 ms |         1,632 ms |
+|[B3.1] 20√N clients concurrently set number in Map (updateSize)           |     49,169 bytes |     49,169 bytes |    161,636 bytes |    283,296 bytes |
+|[B3.1] 20√N clients concurrently set number in Map (encodeTime)           |             2 ms |             1 ms |             2 ms |            11 ms |
+|[B3.1] 20√N clients concurrently set number in Map (docSize)              |     32,225 bytes |     32,209 bytes |     21,506 bytes |     86,167 bytes |
+|[B3.1] 20√N clients concurrently set number in Map (memUsed)              |              0 B |            176 B |            824 B |            344 B |
+|[B3.1] 20√N clients concurrently set number in Map (parseTime)            |           104 ms |            70 ms |            40 ms |            37 ms |
+|[B3.2] 20√N clients concurrently set Object in Map (time)                 |            84 ms |           278 ms |            67 ms |         1,726 ms |
+|[B3.2] 20√N clients concurrently set Object in Map (updateSize)           |     85,082 bytes |     85,085 bytes |    200,630 bytes |    398,090 bytes |
+|[B3.2] 20√N clients concurrently set Object in Map (encodeTime)           |             3 ms |             2 ms |             2 ms |            30 ms |
+|[B3.2] 20√N clients concurrently set Object in Map (docSize)              |     32,235 bytes |     32,249 bytes |     40,494 bytes |    112,570 bytes |
+|[B3.2] 20√N clients concurrently set Object in Map (memUsed)              |              0 B |              0 B |            136 B |              0 B |
+|[B3.2] 20√N clients concurrently set Object in Map (parseTime)            |           102 ms |            70 ms |            45 ms |            86 ms |
+|[B3.3] 20√N clients concurrently set String in Map (time)                 |            86 ms |           299 ms |           116 ms |         2,335 ms |
+|[B3.3] 20√N clients concurrently set String in Map (updateSize)           |  7,826,222 bytes |  7,826,231 bytes |  7,940,240 bytes |  8,063,440 bytes |
+|[B3.3] 20√N clients concurrently set String in Map (encodeTime)           |             2 ms |             1 ms |            46 ms |            91 ms |
+|[B3.3] 20√N clients concurrently set String in Map (docSize)              |     38,357 bytes |     38,376 bytes |  7,798,572 bytes |     98,047 bytes |
+|[B3.3] 20√N clients concurrently set String in Map (memUsed)              |           243 kB |              0 B |            696 B |              0 B |
+|[B3.3] 20√N clients concurrently set String in Map (parseTime)            |            97 ms |            52 ms |            55 ms |           118 ms |
+|[B3.4] 20√N clients concurrently insert text in Array (time)              |            72 ms |           283 ms |           227 ms |         2,780 ms |
+|[B3.4] 20√N clients concurrently insert text in Array (updateSize)        |     52,738 bytes |     52,751 bytes |    166,750 bytes |    311,830 bytes |
+|[B3.4] 20√N clients concurrently insert text in Array (encodeTime)        |             2 ms |             1 ms |             8 ms |            17 ms |
+|[B3.4] 20√N clients concurrently insert text in Array (docSize)           |     26,583 bytes |     26,596 bytes |     31,119 bytes |     96,463 bytes |
+|[B3.4] 20√N clients concurrently insert text in Array (memUsed)           |         588.8 kB |              0 B |            480 B |              0 B |
+|[B3.4] 20√N clients concurrently insert text in Array (parseTime)         |            84 ms |            60 ms |            29 ms |            42 ms |
+|[B4] Apply real-world editing dataset (time)                              |         5,714 ms |        28,675 ms |         3,089 ms |        14,326 ms |
+|[B4] Apply real-world editing dataset (encodeTime)                        |            11 ms |             3 ms |            77 ms |           185 ms |
+|[B4] Apply real-world editing dataset (docSize)                           |    159,929 bytes |    159,929 bytes |    258,228 bytes |    129,116 bytes |
+|[B4] Apply real-world editing dataset (parseTime)                         |            39 ms |            16 ms |            13 ms |         1,805 ms |
+|[B4] Apply real-world editing dataset (memUsed)                           |           3.2 MB |              0 B |              0 B |              0 B |
+|[B4x100] Apply real-world editing dataset 100 times (time)                |       608,908 ms |     2,829,633 ms |       309,689 ms |          skipped |
+|[B4x100] Apply real-world editing dataset 100 times (encodeTime)          |           365 ms |           186 ms |        14,429 ms |          skipped |
+|[B4x100] Apply real-world editing dataset 100 times (docSize)             | 15,989,244 bytes | 15,989,245 bytes | 25,805,795 bytes |          skipped |
+|[B4x100] Apply real-world editing dataset 100 times (parseTime)           |         2,622 ms |         1,328 ms |         1,304 ms |          skipped |
+|[B4x100] Apply real-world editing dataset 100 times (memUsed)             |         327.1 MB |             24 B |           2.1 kB |          skipped |
 
 ##### Older benchmark results that include automerge & delta-crdts
 

--- a/README.md
+++ b/README.md
@@ -68,17 +68,34 @@ Replay the [B4] dataset one hundred times. The final document has a size of over
 ### Results
 
 **Notes**
-* The benchmarks were performed on a desktop computer "Intel® Core™ i5-8400 CPU @ 2.80GHz × 6" and Node 20.5.0.
-* There is a more exchaustive benchmark at the bottom that only runs benchmarks on Yjs.
-* `memUsed` only approximates the amount of memory used. We run the JavaScript garbage collector and use the heap-size difference before and after the benchmark is performed. If the heap is highly fragmented, the heap size might be larger than the actual amount of data stored in the heap. In some cases this even leads to a `memUsed` of less than zero.
+* The benchmarks were performed on a desktop computer "Intel® Core™ i5-8400 CPU
+@ 2.80GHz × 6" and Node 20.5.0.
+* There is a more exchaustive benchmark at the bottom that only runs benchmarks
+on Yjs.
+* `memUsed` only approximates the amount of memory used. We run the JavaScript
+garbage collector and use the heap-size difference before and after the
+benchmark is performed. If the heap is highly fragmented, the heap size might be
+larger than the actual amount of data stored in the heap. In some cases this
+even leads to a `memUsed` of less than zero.
 * `memUsed` does not measure the memory usage of the wasm runtime.
 * Automerge can perform the `B4` benchmark in about 1 second (see `time`) if all
 changes are applied within a single `change` transaction. However, our
 benchmarks test individual edits that generate individual update events as this
 more closely simulates actual user behavior. See #21
-* Note that `parseTime` is significantly longer with `automerge` when the
-initial document is not empty (e.g. when syncing content from a remote server).
-* Preliminary benchmark results for native implementation of the [Ron/Chronofold CRDT](https://github.com/gritzko/ron) (written in C++) are posted [in this thread](https://github.com/dmonad/crdt-benchmarks/issues/3).
+* Note that `parseTime` is significantly higher with `automerge` and `loro` when
+the initial document is not empty (e.g. when syncing content from a remote
+server). 
+* Loro has a concept named `snapshot`, which can significantly reduce
+loading time as it contains the operations **and** the in-memory
+representation of the document. Note that this feature is only useful in
+local-first applications that store the document in regular intervals locally
+(which has it's own set of drawbacks, as encoding will block the ui).
+Hence, I opted to disable this feature, which might seem unfair. You can
+re-enable this feature by uncommenting  You can re-enable this feature in
+`./benchmarks/loro/factory.js`.
+* Preliminary benchmark results for native implementation of the [Ron/Chronofold
+CRDT](https://github.com/gritzko/ron) (written in C++) are posted [in this
+thread](https://github.com/dmonad/crdt-benchmarks/issues/3).
 
 |N = 6000 | [yjs](https://github.com/yjs/yjs) | [ywasm](https://github.com/y-crdt/y-crdt/tree/main/ywasm) | [automerge](https://github.com/automerge/automerge/) |
 | :- |  -: | -: | -:  |
@@ -455,8 +472,6 @@ initial document is not empty (e.g. when syncing content from a remote server).
 |[B4 x 100] Apply real-world editing dataset 100 times (docSize)           |  15989245 bytes |                 |
 |[B4 x 100] Apply real-world editing dataset 100 times (parseTime)         |         2127 ms |                 |
 |[B4 x 100] Apply real-world editing dataset 100 times (memUsed)           |        165.5 MB |                 |
-
-
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,10 @@ server).
 * Loro has a concept named `snapshot`, which can significantly reduce
 loading time as it contains the operations **and** the in-memory
 representation of the document. Note that this feature is only useful in
-local-first applications that store the document in regular intervals locally
-(which has it's own set of drawbacks, as encoding will block the ui).
-Hence, I opted to disable this feature, which might seem unfair. You can
-re-enable this feature by uncommenting  You can re-enable this feature in
+applications that persist the document in regular intervals
+(which has it's own set of drawbacks, as encoding will block the ui). We enabled
+this feature by default. You can disable/enable this feature in
 `./benchmarks/loro/factory.js`.
-* Preliminary benchmark results for native implementation of the [Ron/Chronofold
-CRDT](https://github.com/gritzko/ron) (written in C++) are posted [in this
-thread](https://github.com/dmonad/crdt-benchmarks/issues/3).
 
 |N = 6000 | [yjs](https://github.com/yjs/yjs) | [ywasm](https://github.com/y-crdt/y-crdt/tree/main/ywasm) | [loro](https://github.com/loro-dev/loro) | [automerge](https://github.com/automerge/automerge/) |
 | :- |  -: | -: | -: | -:  |

--- a/benchmarks/automerge-wasm/factory.js
+++ b/benchmarks/automerge-wasm/factory.js
@@ -14,14 +14,14 @@ export const name = 'automerge-wasm'
  */
 export class AutomergeFactory {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    */
   create (updateHandler) {
     return new AutomergeCRDT(updateHandler)
   }
 
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    * @param {Uint8Array} bin
    * @return {AbstractCrdt}
    */
@@ -39,7 +39,7 @@ export class AutomergeFactory {
  */
 export class AutomergeCRDT {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    * @param {Uint8Array} bin
    */
   constructor (updateHandler, bin = INITIAL_DOC_BINARY) {
@@ -48,7 +48,7 @@ export class AutomergeCRDT {
   }
 
   update () {
-    if (this.updateHandler) this.updateHandler(this.doc.saveIncremental())
+    this.updateHandler(this.doc.saveIncremental())
   }
 
   /**

--- a/benchmarks/automerge-wasm/rollup.config.js
+++ b/benchmarks/automerge-wasm/rollup.config.js
@@ -20,20 +20,20 @@ const terserPlugin = terser({
 })
 
 export default [
-{
-  input: './bundle.js',
-  output: {
-    dir: './dist',
-    format: 'es'
-  },
-  plugins: [
-    nodeResolve({
-      mainFields: ['main', 'module'],
-      preferBuiltins: false
-    }),
-    commonjs(),
-    builtins(),
-    globals(),
-    terserPlugin
-  ]
-}]
+  {
+    input: './bundle.js',
+    output: {
+      dir: './dist',
+      format: 'es'
+    },
+    plugins: [
+      nodeResolve({
+        mainFields: ['main', 'module'],
+        preferBuiltins: false
+      }),
+      commonjs(),
+      builtins(),
+      globals(),
+      terserPlugin
+    ]
+  }]

--- a/benchmarks/automerge/benchmark.html
+++ b/benchmarks/automerge/benchmark.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Testing Automerge</title>
+</head>
+<body>
+  <script type="module" src="./dist/benchmark-browser.js"></script>
+</body>
+</html>

--- a/benchmarks/automerge/bundle.js
+++ b/benchmarks/automerge/bundle.js
@@ -1,1 +1,1 @@
-export * from '@automerge/automerge'
+export { next } from '@automerge/automerge'

--- a/benchmarks/automerge/factory.js
+++ b/benchmarks/automerge/factory.js
@@ -16,14 +16,14 @@ export const name = 'automerge'
  */
 export class AutomergeFactory {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    */
   create (updateHandler) {
     return new AutomergeCRDT(updateHandler)
   }
 
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    * @param {Uint8Array} bin
    */
   load (updateHandler, bin) {
@@ -40,7 +40,7 @@ export class AutomergeFactory {
  */
 export class AutomergeCRDT {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    * @param {Uint8Array} init
    */
   constructor (updateHandler, init = initialDocBinary) {
@@ -56,7 +56,7 @@ export class AutomergeCRDT {
   }
 
   update () {
-    if (this.updateHandler) this.updateHandler(automerge.saveIncremental(this.doc))
+    this.updateHandler(automerge.saveIncremental(this.doc))
   }
 
   /**

--- a/benchmarks/loro/benchmark.html
+++ b/benchmarks/loro/benchmark.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Testing Yjs</title>
+</head>
+<body>
+  <script type="module" src="./dist/benchmark-browser.js"></script>
+</body>
+</html>

--- a/benchmarks/loro/benchmark.html
+++ b/benchmarks/loro/benchmark.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Testing Yjs</title>
+  <title>Testing Loro</title>
 </head>
 <body>
   <script type="module" src="./dist/benchmark-browser.js"></script>

--- a/benchmarks/loro/bundle.js
+++ b/benchmarks/loro/bundle.js
@@ -1,0 +1,1 @@
+export * from 'yjs'

--- a/benchmarks/loro/bundle.js
+++ b/benchmarks/loro/bundle.js
@@ -1,1 +1,1 @@
-export * from 'loro-crdt'
+export { Loro } from 'loro-crdt'

--- a/benchmarks/loro/bundle.js
+++ b/benchmarks/loro/bundle.js
@@ -1,1 +1,1 @@
-export * from 'yjs'
+export * from 'loro-crdt'

--- a/benchmarks/loro/factory.js
+++ b/benchmarks/loro/factory.js
@@ -1,0 +1,171 @@
+
+import { AbstractCrdt, CrdtFactory } from '../../js-lib/index.js' // eslint-disable-line
+import * as loro from 'loro-crdt'
+
+export const name = 'loro'
+
+/**
+ * @implements {CrdtFactory}
+ */
+export class LoroFactory {
+  /**
+   * @param {function(Uint8Array):void} [updateHandler]
+   */
+  create (updateHandler) {
+    return new LoroCRDT(updateHandler)
+  }
+
+  /**
+   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {Uint8Array} bin
+   * @return {AbstractCrdt}
+   */
+  load (updateHandler, bin) {
+    const crdt = new LoroCRDT(updateHandler)
+    crdt.applyUpdate(bin)
+    return crdt
+  }
+
+  getName () {
+    return name
+  }
+}
+
+/**
+ * @implements {AbstractCrdt}
+ */
+export class LoroCRDT {
+  /**
+   * @param {function(Uint8Array):void} [updateHandler]
+   */
+  constructor (updateHandler) {
+    this.doc = new loro.Loro()
+    this.updateHandler = updateHandler
+    this.array = this.doc.getList('list')
+    this.map = this.doc.getMap('map')
+    this.text = this.doc.getText('text')
+    this._tr = false
+  }
+
+  /**
+   * @return {Uint8Array|string}
+   */
+  getEncodedState () {
+    /**
+     * Snapshots store the operation log AND the in-memory representation of the
+     * document.
+     *
+     * Normal updates only store the operation log.
+     *
+     * We use the update format since this is what would be used in practice. I will update this
+     * once it can be shown that there is a loro network backend that uses this feature.
+     */
+    // return this.doc.exportSnapshot() // use snapshots instead
+    return this.doc.exportFrom()
+  }
+
+  /**
+   * @param {Uint8Array} update
+   */
+  applyUpdate (update) {
+    this.doc.import(update)
+  }
+
+  /**
+   * Insert several items into the internal shared array implementation.
+   *
+   * @param {number} index
+   * @param {Array<any>} elems
+   */
+  insertArray (index, elems) {
+    this.transact(() => {
+      elems.forEach((e, i) => {
+        this.array.insert(index + i, e)
+      })
+    })
+  }
+
+  /**
+   * Delete several items into the internal shared array implementation.
+   *
+   * @param {number} index
+   * @param {number} len
+   */
+  deleteArray (index, len) {
+    this.transact(() => {
+      this.array.delete(index, len)
+    })
+  }
+
+  /**
+   * @return {Array<any>}
+   */
+  getArray () {
+    return this.array.toArray()
+  }
+
+  /**
+   * Insert text into the internal shared text implementation.
+   *
+   * @param {number} index
+   * @param {string} text
+   */
+  insertText (index, text) {
+    this.transact(() => {
+      this.text.insert(index, text)
+    })
+  }
+
+  /**
+   * Delete text from the internal shared text implementation.
+   *
+   * @param {number} index
+   * @param {number} len
+   */
+  deleteText (index, len) {
+    this.transact(() => {
+      this.text.delete(index, len)
+    })
+  }
+
+  /**
+   * @return {string}
+   */
+  getText () {
+    return this.text.toString()
+  }
+
+  /**
+   * @param {function (AbstractCrdt, loro.Loro): void} f
+   */
+  transact (f) {
+    if (this._tr) {
+      f(this, this.doc)
+      return
+    }
+    this._tr = true
+    // potentially we could cache version here?
+    const version = this.doc.version()
+    f(this, this.doc)
+    this.doc.commit()
+    this._tr = false
+    if (this.updateHandler) this.updateHandler(this.doc.exportFrom(version))
+  }
+
+  /**
+   * @param {string} key
+   * @param {any} val
+   */
+  setMap (key, val) {
+    this.transact(() => {
+      this.map.set(key, val)
+    })
+  }
+
+  /**
+   * @return {Map<string,any> | Object<string, any>}
+   */
+  getMap () {
+    return this.map.toJson()
+  }
+}

--- a/benchmarks/loro/factory.js
+++ b/benchmarks/loro/factory.js
@@ -1,5 +1,4 @@
 
-
 import { AbstractCrdt, CrdtFactory } from '../../js-lib/index.js' // eslint-disable-line
 import { Loro } from 'loro-crdt'
 
@@ -10,24 +9,24 @@ export const name = 'loro'
  */
 export class LoroFactory {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    */
-  create(updateHandler) {
+  create (updateHandler) {
     return new LoroWasm(updateHandler)
   }
 
   /**
- * @param {function(Uint8Array):void} [updateHandler]
+ * @param {function(Uint8Array):void} updateHandler
  * @param {Uint8Array} [bin]
  * @return {AbstractCrdt}
  */
-  load(updateHandler, bin) {
-    const doc = new LoroWasm(updateHandler);
-    bin && doc.doc.import(bin);
+  load (updateHandler, bin) {
+    const doc = new LoroWasm(updateHandler)
+    bin && doc.doc.import(bin)
     return doc
   }
 
-  getName() {
+  getName () {
     return name
   }
 }
@@ -37,40 +36,46 @@ export class LoroFactory {
  */
 export class LoroWasm {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    */
-  constructor(updateHandler) {
-    this.doc = new Loro();
-    this.version = undefined;
-    this.updateHandler = updateHandler;
+  constructor (updateHandler) {
+    this.doc = new Loro()
+    this.version = undefined
+    this.updateHandler = updateHandler
     this.list = this.doc.getList('list')
     this.map = this.doc.getMap('map')
     this.text = this.doc.getText('text')
-    this.cachedUpdates = [];
-  }
-
-  update() {
-    if (this.updateHandler) {
-      this.updateHandler(this.doc.exportFrom(this.version));
-      this.version = this.doc.version();
-    }
+    /**
+     * Cached updates will be applied at the end of the transaction.
+     *
+     * @type {Array<Uint8Array>}
+     */
+    this.cachedUpdates = []
   }
 
   /**
    * @return {Uint8Array|string}
    */
-  getEncodedState() {
-    const ans = this.doc.exportSnapshot()
-    // this.doc.diagnoseOplogSize();
-    return ans;
+  getEncodedState () {
+    /**
+     * Snapshots store the operation log AND the encoded in-memory state of the document. It has
+     * faster loading time,  but the encoded document is larger and it takes longer
+     * to encode.
+     *
+     * Normal updates only store the operation log. They take longer to decode.
+     *
+     * We use the snapshot feature by default, as this is what the Loro team recommends.
+     */
+    return this.doc.exportSnapshot() // use the snapshot format
+    // return this.doc.exportFrom() // use the update format
   }
 
   /**
    * @param {Uint8Array} update
    */
-  applyUpdate(update) {
+  applyUpdate (update) {
     if (this.inTransact) {
-      this.cachedUpdates.push(update);
+      this.cachedUpdates.push(update)
     } else {
       this.doc.import(update)
     }
@@ -82,11 +87,12 @@ export class LoroWasm {
    * @param {number} index
    * @param {Array<any>} elems
    */
-  insertArray(index, elems) {
-    for (let i = 0; i < elems.length; i++) {
-      this.list.insert(index + i, elems[i])
-    }
-    this.update()
+  insertArray (index, elems) {
+    this.transact(() => {
+      for (let i = 0; i < elems.length; i++) {
+        this.list.insert(index + i, elems[i])
+      }
+    })
   }
 
   /**
@@ -95,15 +101,16 @@ export class LoroWasm {
    * @param {number} index
    * @param {number} len
    */
-  deleteArray(index, len) {
-    this.list.delete(index, len);
-    this.update()
+  deleteArray (index, len) {
+    this.transact(() => {
+      this.list.delete(index, len)
+    })
   }
 
   /**
    * @return {Array<any>}
    */
-  getArray() {
+  getArray () {
     return this.list.toArray()
   }
 
@@ -113,9 +120,10 @@ export class LoroWasm {
    * @param {number} index
    * @param {string} text
    */
-  insertText(index, text) {
-    this.text.insert(index, text);
-    this.update()
+  insertText (index, text) {
+    this.transact(() => {
+      this.text.insert(index, text)
+    })
   }
 
   /**
@@ -124,48 +132,52 @@ export class LoroWasm {
    * @param {number} index
    * @param {number} len
    */
-  deleteText(index, len) {
-    this.text.delete(index, len);
-    this.update()
+  deleteText (index, len) {
+    this.transact(() => {
+      this.text.delete(index, len)
+    })
   }
 
   /**
    * @return {string}
    */
-  getText() {
+  getText () {
     return this.text.toString()
   }
 
   /**
    * @param {function (AbstractCrdt): void} f
    */
-  transact(f) {
-    this.cachedUpdates.length = 0;
-    this.inTransact = true;
-    try {
+  transact (f) {
+    if (this.inTransact) {
       f(this)
-    } finally {
-      this.inTransact = false;
-      if (this.cachedUpdates) {
-        this.doc.importUpdateBatch(this.cachedUpdates);
-        this.cachedUpdates = [];
-      }
+      return
     }
+    this.inTransact = true
+    f(this)
+    if (this.cachedUpdates.length > 0) {
+      this.doc.importUpdateBatch(this.cachedUpdates)
+      this.cachedUpdates = []
+    }
+    this.updateHandler(this.doc.exportFrom(this.version))
+    this.version = this.doc.version()
+    this.inTransact = false
   }
 
   /**
    * @param {string} key
    * @param {any} val
    */
-  setMap(key, val) {
-    this.map.set(key, val);
-    this.update();
+  setMap (key, val) {
+    this.transact(() => {
+      this.map.set(key, val)
+    })
   }
 
   /**
    * @return {Map<string,any> | Object<string, any>}
    */
-  getMap() {
+  getMap () {
     return this.map.toJson()
   }
 }

--- a/benchmarks/loro/package-lock.json
+++ b/benchmarks/loro/package-lock.json
@@ -1,44 +1,15 @@
 {
-  "name": "yjs",
+  "name": "loro",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "yjs",
+      "name": "loro",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "loro-crdt": "^0.10.0",
-        "yjs": "^13.5.12"
-      }
-    },
-    "node_modules/isomorphic.js": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
-      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
-    "node_modules/lib0": {
-      "version": "0.2.88",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.88.tgz",
-      "integrity": "sha512-KyroiEvCeZcZEMx5Ys+b4u4eEBbA1ch7XUaBhYpwa/nPMrzTjUhI4RfcytmQfYoTBPcdyx+FX6WFNIoNuJzJfQ==",
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
+        "loro-crdt": "^0.10.0"
       }
     },
     "node_modules/loro-crdt": {
@@ -53,21 +24,6 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/loro-wasm/-/loro-wasm-0.10.0.tgz",
       "integrity": "sha512-BjI2GJmSa92YOlo4NhZDGXKOz+edqOu98qmtiIaRIcGUe9wA/qCq889A23rt3w2SyaQ4HQmj8ODLpIBE1eQgGw=="
-    },
-    "node_modules/yjs": {
-      "version": "13.6.11",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.86"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
     }
   }
 }

--- a/benchmarks/loro/package-lock.json
+++ b/benchmarks/loro/package-lock.json
@@ -13,13 +13,8 @@
         "loro-wasm": "^0.10.1"
       }
     },
-    "node_modules/.pnpm/loro-crdt@0.10.1": {},
-    "node_modules/.pnpm/loro-crdt@0.10.1/node_modules/loro-crdt": {
-      "version": "0.10.1",
-      "license": "MIT",
-      "dependencies": {
-        "loro-wasm": "0.10.1"
-      }
+    "node_modules/.pnpm/loro-crdt@0.10.1": {
+      "extraneous": true
     },
     "node_modules/.pnpm/loro-wasm@0.10.1/node_modules/loro-wasm": {
       "version": "0.10.1",
@@ -31,8 +26,12 @@
       }
     },
     "node_modules/loro-crdt": {
-      "resolved": "node_modules/.pnpm/loro-crdt@0.10.1/node_modules/loro-crdt",
-      "link": true
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/loro-crdt/-/loro-crdt-0.10.1.tgz",
+      "integrity": "sha512-1PlaxcaJirQ7Q4SZ9SW0UfaxFezlXNE4Ccqgd7VdA/KFkRu0/AUQu6uKbR74njoWLzwcupBR7OclFMMEjjh5Eg==",
+      "dependencies": {
+        "loro-wasm": "0.10.1"
+      }
     },
     "node_modules/loro-wasm": {
       "version": "0.10.1",

--- a/benchmarks/loro/package-lock.json
+++ b/benchmarks/loro/package-lock.json
@@ -1,0 +1,73 @@
+{
+  "name": "yjs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yjs",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "loro-crdt": "^0.10.0",
+        "yjs": "^13.5.12"
+      }
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.88",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.88.tgz",
+      "integrity": "sha512-KyroiEvCeZcZEMx5Ys+b4u4eEBbA1ch7XUaBhYpwa/nPMrzTjUhI4RfcytmQfYoTBPcdyx+FX6WFNIoNuJzJfQ==",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/loro-crdt": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/loro-crdt/-/loro-crdt-0.10.0.tgz",
+      "integrity": "sha512-B9rYksjiEyv4nRbkkcU+6FRsvl5WtK9a9s2XPUAQfrBbVXQxZFaSZQHfflHAcWnYeV0JVhFEHfYTYfi5pf35iQ==",
+      "dependencies": {
+        "loro-wasm": "0.10.0"
+      }
+    },
+    "node_modules/loro-wasm": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/loro-wasm/-/loro-wasm-0.10.0.tgz",
+      "integrity": "sha512-BjI2GJmSa92YOlo4NhZDGXKOz+edqOu98qmtiIaRIcGUe9wA/qCq889A23rt3w2SyaQ4HQmj8ODLpIBE1eQgGw=="
+    },
+    "node_modules/yjs": {
+      "version": "13.6.11",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.86"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    }
+  }
+}

--- a/benchmarks/loro/package-lock.json
+++ b/benchmarks/loro/package-lock.json
@@ -9,21 +9,35 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "loro-crdt": "^0.10.0"
+        "loro-crdt": "^0.10.1",
+        "loro-wasm": "^0.10.1"
+      }
+    },
+    "node_modules/.pnpm/loro-crdt@0.10.1": {},
+    "node_modules/.pnpm/loro-crdt@0.10.1/node_modules/loro-crdt": {
+      "version": "0.10.1",
+      "license": "MIT",
+      "dependencies": {
+        "loro-wasm": "0.10.1"
+      }
+    },
+    "node_modules/.pnpm/loro-wasm@0.10.1/node_modules/loro-wasm": {
+      "version": "0.10.1",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "vite-plugin-top-level-await": "^1.2.2",
+        "vite-plugin-wasm": "^3.1.0"
       }
     },
     "node_modules/loro-crdt": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/loro-crdt/-/loro-crdt-0.10.0.tgz",
-      "integrity": "sha512-B9rYksjiEyv4nRbkkcU+6FRsvl5WtK9a9s2XPUAQfrBbVXQxZFaSZQHfflHAcWnYeV0JVhFEHfYTYfi5pf35iQ==",
-      "dependencies": {
-        "loro-wasm": "0.10.0"
-      }
+      "resolved": "node_modules/.pnpm/loro-crdt@0.10.1/node_modules/loro-crdt",
+      "link": true
     },
     "node_modules/loro-wasm": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/loro-wasm/-/loro-wasm-0.10.0.tgz",
-      "integrity": "sha512-BjI2GJmSa92YOlo4NhZDGXKOz+edqOu98qmtiIaRIcGUe9wA/qCq889A23rt3w2SyaQ4HQmj8ODLpIBE1eQgGw=="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/loro-wasm/-/loro-wasm-0.10.1.tgz",
+      "integrity": "sha512-H8NmkUcGyg0bnhTl87Xma7TBoJUtEuq9kKQA+KimHqVj5xi5r1raog8DN3XYVotUzKEC0owRGvt6orJSdYRCtw=="
     }
   }
 }

--- a/benchmarks/loro/package.json
+++ b/benchmarks/loro/package.json
@@ -16,6 +16,7 @@
   "author": "Kevin Jahns",
   "license": "MIT",
   "dependencies": {
-    "loro-crdt": "^0.10.0"
+    "loro-crdt": "^0.10.1",
+    "loro-wasm": "^0.10.1"
   }
 }

--- a/benchmarks/loro/package.json
+++ b/benchmarks/loro/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist",
-    "measure-bundle": "([ -f \"./dist/bundle.js\" ] || npm run dist) && node ../../bin/measure-bundle.js",
+    "measure-bundle": "([ -f \"./dist/bundle.js\" ] || npm run dist) && node ../../bin/measure-bundle.js node_modules/loro-wasm/bundler/loro_wasm_bg.wasm",
     "start": "npm run measure-bundle && node --expose-gc run.js && npm run table",
     "start:bun": "npm run measure-bundle && bun run run.js && npm run table",
     "start:browser": "rollup -c && 0serve -o benchmark.html",

--- a/benchmarks/loro/package.json
+++ b/benchmarks/loro/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "loro",
+  "version": "1.0.0",
+  "description": "Loro benchmarks",
+  "main": "./run.js",
+  "type": "module",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "measure-bundle": "([ -f \"./dist/bundle.js\" ] || npm run dist) && node ../../bin/measure-bundle.js",
+    "start": "npm run measure-bundle && node --expose-gc run.js && npm run table",
+    "start:bun": "npm run measure-bundle && bun run run.js && npm run table",
+    "start:browser": "rollup -c && 0serve -o benchmark.html",
+    "table": "echo 'Loro results: \n\n' && node ../../bin/render-table.js ../results.json 6000 loro",
+    "dist": "npm run clean && rollup -c && gzip --keep dist/*"
+  },
+  "author": "Kevin Jahns",
+  "license": "MIT",
+  "dependencies": {
+    "loro-crdt": "^0.10.0"
+  }
+}

--- a/benchmarks/loro/rollup.config.js
+++ b/benchmarks/loro/rollup.config.js
@@ -1,0 +1,3 @@
+import rollupConfig from '../../js-lib/rollup-helper.js'
+
+export default rollupConfig

--- a/benchmarks/loro/run.js
+++ b/benchmarks/loro/run.js
@@ -1,7 +1,7 @@
 import { LoroFactory } from './factory.js'
 import { runBenchmarks, writeBenchmarkResultsToFile } from '../../js-lib/index.js'
 
-  ; (async () => {
-    await runBenchmarks(new LoroFactory(), testName => true);
-    writeBenchmarkResultsToFile('../results.json', testName => true)
-  })()
+; (async () => {
+  await runBenchmarks(new LoroFactory(), testName => true)
+  writeBenchmarkResultsToFile('../results.json', testName => true)
+})()

--- a/benchmarks/loro/run.js
+++ b/benchmarks/loro/run.js
@@ -2,6 +2,6 @@ import { LoroFactory } from './factory.js'
 import { runBenchmarks, writeBenchmarkResultsToFile } from '../../js-lib/index.js'
 
 ;(async () => {
-  await runBenchmarks(new LoroFactory(), testName => true) // !testName.startsWith('[B4x'))
+  await runBenchmarks(new LoroFactory(), testName => !testName.startsWith('[B4x100'))
   writeBenchmarkResultsToFile('../results.json', testName => true)
 })()

--- a/benchmarks/loro/run.js
+++ b/benchmarks/loro/run.js
@@ -1,7 +1,7 @@
 import { LoroFactory } from './factory.js'
 import { runBenchmarks, writeBenchmarkResultsToFile } from '../../js-lib/index.js'
 
-;(async () => {
-  await runBenchmarks(new LoroFactory(), testName => !testName.startsWith('[B4x100'))
-  writeBenchmarkResultsToFile('../results.json', testName => true)
-})()
+  ; (async () => {
+    await runBenchmarks(new LoroFactory(), testName => true);
+    writeBenchmarkResultsToFile('../results.json', testName => true)
+  })()

--- a/benchmarks/loro/run.js
+++ b/benchmarks/loro/run.js
@@ -1,0 +1,7 @@
+import { LoroFactory } from './factory.js'
+import { runBenchmarks, writeBenchmarkResultsToFile } from '../../js-lib/index.js'
+
+;(async () => {
+  await runBenchmarks(new LoroFactory(), testName => true) // !testName.startsWith('[B4x'))
+  writeBenchmarkResultsToFile('../results.json', testName => true)
+})()

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -8,25 +8,25 @@
       "loro": "0.10.1"
     },
     "Bundle size": {
-      "yjs": "80413 bytes",
+      "yjs": "128226 bytes",
       "ywasm": "677652 bytes",
       "automerge-wasm": "1695301 bytes",
       "automerge": "1737571 bytes",
       "loro": "1052250 bytes"
     },
     "Bundle size (gzipped)": {
-      "yjs": "23571 bytes",
+      "yjs": "38816 bytes",
       "ywasm": "213832 bytes",
       "automerge-wasm": "592235 bytes",
       "automerge": "604118 bytes",
-      "loro": "399686 bytes"
+      "loro": "399276 bytes"
     },
     "[B1.1] Append N characters (time)": {
       "yjs": "164 ms",
       "ywasm": "135 ms",
       "automerge-wasm": "117 ms",
       "automerge": "364 ms",
-      "loro": "218 ms"
+      "loro": "119 ms"
     },
     "[B1.1] Append N characters (avgUpdateSize)": {
       "yjs": "27 bytes",
@@ -40,7 +40,7 @@
       "ywasm": "1 ms",
       "automerge-wasm": "7 ms",
       "automerge": "7 ms",
-      "loro": "0 ms"
+      "loro": "1 ms"
     },
     "[B1.1] Append N characters (docSize)": {
       "yjs": "6031 bytes",
@@ -54,14 +54,14 @@
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "353.1 kB"
+      "loro": "0 B"
     },
     "[B1.1] Append N characters (parseTime)": {
       "yjs": "46 ms",
       "ywasm": "43 ms",
       "automerge-wasm": "91 ms",
       "automerge": "95 ms",
-      "loro": "45 ms"
+      "loro": "39 ms"
     },
     "[B1.2] Insert string of length N (time)": {
       "yjs": "1 ms",
@@ -96,21 +96,21 @@
       "ywasm": "424.3 kB",
       "automerge-wasm": "840 B",
       "automerge": "9.2 kB",
-      "loro": "0 B"
+      "loro": "13.2 kB"
     },
     "[B1.2] Insert string of length N (parseTime)": {
       "yjs": "56 ms",
       "ywasm": "44 ms",
       "automerge-wasm": "53 ms",
       "automerge": "43 ms",
-      "loro": "40 ms"
+      "loro": "42 ms"
     },
     "[B1.3] Prepend N characters (time)": {
       "yjs": "132 ms",
       "ywasm": "21 ms",
       "automerge-wasm": "86 ms",
       "automerge": "314 ms",
-      "loro": "49 ms"
+      "loro": "75 ms"
     },
     "[B1.3] Prepend N characters (avgUpdateSize)": {
       "yjs": "27 bytes",
@@ -124,7 +124,7 @@
       "ywasm": "0 ms",
       "automerge-wasm": "5 ms",
       "automerge": "5 ms",
-      "loro": "16 ms"
+      "loro": "10 ms"
     },
     "[B1.3] Prepend N characters (docSize)": {
       "yjs": "6041 bytes",
@@ -138,21 +138,21 @@
       "ywasm": "8.3 kB",
       "automerge-wasm": "7.9 kB",
       "automerge": "0 B",
-      "loro": "0 B"
+      "loro": "7.7 kB"
     },
     "[B1.3] Prepend N characters (parseTime)": {
       "yjs": "85 ms",
       "ywasm": "50 ms",
       "automerge-wasm": "90 ms",
       "automerge": "96 ms",
-      "loro": "54 ms"
+      "loro": "41 ms"
     },
     "[B1.4] Insert N characters at random positions (time)": {
       "yjs": "145 ms",
       "ywasm": "130 ms",
       "automerge-wasm": "105 ms",
       "automerge": "314 ms",
-      "loro": "39 ms"
+      "loro": "74 ms"
     },
     "[B1.4] Insert N characters at random positions (avgUpdateSize)": {
       "yjs": "29 bytes",
@@ -166,7 +166,7 @@
       "ywasm": "1 ms",
       "automerge-wasm": "8 ms",
       "automerge": "9 ms",
-      "loro": "23 ms"
+      "loro": "35 ms"
     },
     "[B1.4] Insert N characters at random positions (docSize)": {
       "yjs": "29554 bytes",
@@ -180,21 +180,21 @@
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "9.5 kB",
-      "loro": "0 B"
+      "loro": "7.9 kB"
     },
     "[B1.4] Insert N characters at random positions (parseTime)": {
       "yjs": "90 ms",
       "ywasm": "43 ms",
       "automerge-wasm": "105 ms",
       "automerge": "106 ms",
-      "loro": "33 ms"
+      "loro": "40 ms"
     },
     "[B1.5] Insert N words at random positions (time)": {
       "yjs": "166 ms",
       "ywasm": "438 ms",
       "automerge-wasm": "326 ms",
       "automerge": "515 ms",
-      "loro": "38 ms"
+      "loro": "76 ms"
     },
     "[B1.5] Insert N words at random positions (avgUpdateSize)": {
       "yjs": "36 bytes",
@@ -208,7 +208,7 @@
       "ywasm": "1 ms",
       "automerge-wasm": "21 ms",
       "automerge": "23 ms",
-      "loro": "46 ms"
+      "loro": "69 ms"
     },
     "[B1.5] Insert N words at random positions (docSize)": {
       "yjs": "87924 bytes",
@@ -222,14 +222,14 @@
       "ywasm": "720 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "0 B"
+      "loro": "2.4 kB"
     },
     "[B1.5] Insert N words at random positions (parseTime)": {
       "yjs": "74 ms",
       "ywasm": "48 ms",
       "automerge-wasm": "147 ms",
       "automerge": "171 ms",
-      "loro": "31 ms"
+      "loro": "45 ms"
     },
     "[B1.6] Insert string, then delete it (time)": {
       "yjs": "2 ms",
@@ -271,14 +271,14 @@
       "ywasm": "43 ms",
       "automerge-wasm": "54 ms",
       "automerge": "67 ms",
-      "loro": "29 ms"
+      "loro": "38 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (time)": {
       "yjs": "171 ms",
       "ywasm": "137 ms",
       "automerge-wasm": "247 ms",
       "automerge": "462 ms",
-      "loro": "46 ms"
+      "loro": "92 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (avgUpdateSize)": {
       "yjs": "31 bytes",
@@ -292,7 +292,7 @@
       "ywasm": "1 ms",
       "automerge-wasm": "20 ms",
       "automerge": "21 ms",
-      "loro": "11 ms"
+      "loro": "17 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (docSize)": {
       "yjs": "28377 bytes",
@@ -306,21 +306,21 @@
       "ywasm": "480 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "0 B"
+      "loro": "1.8 kB"
     },
     "[B1.7] Insert/Delete strings at random positions (parseTime)": {
       "yjs": "93 ms",
       "ywasm": "46 ms",
       "automerge-wasm": "131 ms",
       "automerge": "136 ms",
-      "loro": "27 ms"
+      "loro": "40 ms"
     },
     "[B1.8] Append N numbers (time)": {
       "yjs": "160 ms",
       "ywasm": "26 ms",
       "automerge-wasm": "120 ms",
       "automerge": "455 ms",
-      "loro": "41 ms"
+      "loro": "76 ms"
     },
     "[B1.8] Append N numbers (avgUpdateSize)": {
       "yjs": "32 bytes",
@@ -355,14 +355,14 @@
       "ywasm": "43 ms",
       "automerge-wasm": "97 ms",
       "automerge": "101 ms",
-      "loro": "33 ms"
+      "loro": "37 ms"
     },
     "[B1.9] Insert Array of N numbers (time)": {
       "yjs": "5 ms",
       "ywasm": "3 ms",
       "automerge-wasm": "8 ms",
       "automerge": "40 ms",
-      "loro": "9 ms"
+      "loro": "8 ms"
     },
     "[B1.9] Insert Array of N numbers (avgUpdateSize)": {
       "yjs": "35657 bytes",
@@ -390,21 +390,21 @@
       "ywasm": "552 B",
       "automerge-wasm": "344 B",
       "automerge": "37.9 kB",
-      "loro": "0 B"
+      "loro": "2.6 kB"
     },
     "[B1.9] Insert Array of N numbers (parseTime)": {
       "yjs": "58 ms",
       "ywasm": "42 ms",
       "automerge-wasm": "57 ms",
       "automerge": "68 ms",
-      "loro": "28 ms"
+      "loro": "38 ms"
     },
     "[B1.10] Prepend N numbers (time)": {
       "yjs": "129 ms",
       "ywasm": "27 ms",
       "automerge-wasm": "214 ms",
       "automerge": "530 ms",
-      "loro": "40 ms"
+      "loro": "78 ms"
     },
     "[B1.10] Prepend N numbers (avgUpdateSize)": {
       "yjs": "32 bytes",
@@ -418,7 +418,7 @@
       "ywasm": "1 ms",
       "automerge-wasm": "9 ms",
       "automerge": "8 ms",
-      "loro": "6 ms"
+      "loro": "9 ms"
     },
     "[B1.10] Prepend N numbers (docSize)": {
       "yjs": "35665 bytes",
@@ -432,21 +432,21 @@
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "65.7 kB",
-      "loro": "0 B"
+      "loro": "249.3 kB"
     },
     "[B1.10] Prepend N numbers (parseTime)": {
       "yjs": "73 ms",
       "ywasm": "45 ms",
       "automerge-wasm": "98 ms",
       "automerge": "106 ms",
-      "loro": "28 ms"
+      "loro": "40 ms"
     },
     "[B1.11] Insert N numbers at random positions (time)": {
       "yjs": "144 ms",
       "ywasm": "149 ms",
       "automerge-wasm": "130 ms",
       "automerge": "470 ms",
-      "loro": "39 ms"
+      "loro": "78 ms"
     },
     "[B1.11] Insert N numbers at random positions (avgUpdateSize)": {
       "yjs": "34 bytes",
@@ -460,7 +460,7 @@
       "ywasm": "1 ms",
       "automerge-wasm": "9 ms",
       "automerge": "11 ms",
-      "loro": "24 ms"
+      "loro": "36 ms"
     },
     "[B1.11] Insert N numbers at random positions (docSize)": {
       "yjs": "59137 bytes",
@@ -474,14 +474,14 @@
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "60.1 kB",
-      "loro": "0 B"
+      "loro": "2.3 kB"
     },
     "[B1.11] Insert N numbers at random positions (parseTime)": {
       "yjs": "93 ms",
       "ywasm": "51 ms",
       "automerge-wasm": "127 ms",
       "automerge": "104 ms",
-      "loro": "28 ms"
+      "loro": "44 ms"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (time)": {
       "yjs": "3 ms",
@@ -516,35 +516,35 @@
       "ywasm": "304 B",
       "automerge-wasm": "864 B",
       "automerge": "14.5 kB",
-      "loro": "1.9 kB"
+      "loro": "2 kB"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (parseTime)": {
       "yjs": "62 ms",
       "ywasm": "41 ms",
       "automerge-wasm": "55 ms",
       "automerge": "64 ms",
-      "loro": "28 ms"
+      "loro": "40 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (time)": {
       "yjs": "72 ms",
       "ywasm": "405 ms",
       "automerge-wasm": "677 ms",
       "automerge": "311 ms",
-      "loro": "204 ms"
+      "loro": "82 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (updateSize)": {
       "yjs": "33444 bytes",
       "ywasm": "177007 bytes",
       "automerge-wasm": "1093293 bytes",
       "automerge": "27476 bytes",
-      "loro": "665563 bytes"
+      "loro": "35554 bytes"
     },
     "[B2.2] Concurrently insert N characters at random positions (encodeTime)": {
       "yjs": "2 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "17 ms",
       "automerge": "10 ms",
-      "loro": "57 ms"
+      "loro": "83 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (docSize)": {
       "yjs": "66860 bytes",
@@ -565,98 +565,98 @@
       "ywasm": "52 ms",
       "automerge-wasm": "151 ms",
       "automerge": "67 ms",
-      "loro": "53 ms"
+      "loro": "43 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (time)": {
       "yjs": "86 ms",
       "ywasm": "1046 ms",
       "automerge-wasm": "1050 ms",
       "automerge": "701 ms",
-      "loro": "213 ms"
+      "loro": "111 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (updateSize)": {
       "yjs": "88994 bytes",
       "ywasm": "215213 bytes",
       "automerge-wasm": "1185202 bytes",
       "automerge": "122485 bytes",
-      "loro": "731420 bytes"
+      "loro": "93132 bytes"
     },
     "[B2.3] Concurrently insert N words at random positions (encodeTime)": {
       "yjs": "4 ms",
       "ywasm": "4 ms",
       "automerge-wasm": "59 ms",
       "automerge": "37 ms",
-      "loro": "98 ms"
+      "loro": "145 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (docSize)": {
       "yjs": "178137 bytes",
       "ywasm": "178137 bytes",
       "automerge-wasm": "191497 bytes",
       "automerge": "185019 bytes",
-      "loro": "188458 bytes"
+      "loro": "188456 bytes"
     },
     "[B2.3] Concurrently insert N words at random positions (memUsed)": {
       "yjs": "5.6 MB",
       "ywasm": "432 B",
       "automerge-wasm": "18.4 kB",
       "automerge": "0 B",
-      "loro": "0 B"
+      "loro": "1.5 kB"
     },
     "[B2.3] Concurrently insert N words at random positions (parseTime)": {
       "yjs": "76 ms",
       "ywasm": "73 ms",
       "automerge-wasm": "317 ms",
       "automerge": "190 ms",
-      "loro": "49 ms"
+      "loro": "66 ms"
     },
     "[B2.4] Concurrently insert & delete (time)": {
       "yjs": "232 ms",
       "ywasm": "2740 ms",
       "automerge-wasm": "2564 ms",
       "automerge": "1113 ms",
-      "loro": "427 ms"
+      "loro": "204 ms"
     },
     "[B2.4] Concurrently insert & delete (updateSize)": {
       "yjs": "139517 bytes",
       "ywasm": "398881 bytes",
       "automerge-wasm": "2395876 bytes",
       "automerge": "298810 bytes",
-      "loro": "1441427 bytes"
+      "loro": "163564 bytes"
     },
     "[B2.4] Concurrently insert & delete (encodeTime)": {
       "yjs": "21 ms",
       "ywasm": "7 ms",
       "automerge-wasm": "76 ms",
       "automerge": "62 ms",
-      "loro": "155 ms"
+      "loro": "245 ms"
     },
     "[B2.4] Concurrently insert & delete (docSize)": {
       "yjs": "279172 bytes",
       "ywasm": "279172 bytes",
       "automerge-wasm": "307291 bytes",
       "automerge": "293829 bytes",
-      "loro": "289590 bytes"
+      "loro": "289595 bytes"
     },
     "[B2.4] Concurrently insert & delete (memUsed)": {
       "yjs": "9.4 MB",
       "ywasm": "432 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "0 B"
+      "loro": "1.7 kB"
     },
     "[B2.4] Concurrently insert & delete (parseTime)": {
       "yjs": "142 ms",
       "ywasm": "84 ms",
       "automerge-wasm": "434 ms",
       "automerge": "278 ms",
-      "loro": "53 ms"
+      "loro": "70 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (time)": {
       "yjs": "91 ms",
       "ywasm": "276 ms",
       "automerge-wasm": "34 ms",
       "automerge": "1616 ms",
-      "loro": "43 ms"
+      "loro": "58 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (updateSize)": {
       "yjs": "49181 bytes",
@@ -670,7 +670,7 @@
       "ywasm": "2 ms",
       "automerge-wasm": "20 ms",
       "automerge": "12 ms",
-      "loro": "3 ms"
+      "loro": "2 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (docSize)": {
       "yjs": "32246 bytes",
@@ -684,21 +684,21 @@
       "ywasm": "272 B",
       "automerge-wasm": "480 B",
       "automerge": "0 B",
-      "loro": "0 B"
+      "loro": "608 B"
     },
     "[B3.1] 20√N clients concurrently set number in Map (parseTime)": {
       "yjs": "100 ms",
       "ywasm": "77 ms",
       "automerge-wasm": "77 ms",
       "automerge": "48 ms",
-      "loro": "46 ms"
+      "loro": "71 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (time)": {
       "yjs": "84 ms",
       "ywasm": "284 ms",
       "automerge-wasm": "45 ms",
       "automerge": "1727 ms",
-      "loro": "50 ms"
+      "loro": "72 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (updateSize)": {
       "yjs": "85082 bytes",
@@ -719,28 +719,28 @@
       "ywasm": "32218 bytes",
       "automerge-wasm": "93420 bytes",
       "automerge": "112588 bytes",
-      "loro": "40494 bytes"
+      "loro": "41858 bytes"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (memUsed)": {
       "yjs": "232.4 kB",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "584 B"
+      "loro": "0 B"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (parseTime)": {
       "yjs": "93 ms",
       "ywasm": "75 ms",
       "automerge-wasm": "100 ms",
       "automerge": "93 ms",
-      "loro": "75 ms"
+      "loro": "84 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (time)": {
       "yjs": "88 ms",
       "ywasm": "299 ms",
       "automerge-wasm": "232 ms",
       "automerge": "2644 ms",
-      "loro": "115 ms"
+      "loro": "116 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (updateSize)": {
       "yjs": "7826225 bytes",
@@ -754,35 +754,35 @@
       "ywasm": "1 ms",
       "automerge-wasm": "96 ms",
       "automerge": "105 ms",
-      "loro": "46 ms"
+      "loro": "51 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (docSize)": {
       "yjs": "38370 bytes",
       "ywasm": "35296 bytes",
       "automerge-wasm": "97995 bytes",
       "automerge": "98003 bytes",
-      "loro": "7798572 bytes"
+      "loro": "7799994 bytes"
     },
     "[B3.3] 20√N clients concurrently set String in Map (memUsed)": {
       "yjs": "179.2 kB",
       "ywasm": "200 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "488 B"
+      "loro": "704 B"
     },
     "[B3.3] 20√N clients concurrently set String in Map (parseTime)": {
       "yjs": "104 ms",
       "ywasm": "86 ms",
       "automerge-wasm": "123 ms",
       "automerge": "130 ms",
-      "loro": "51 ms"
+      "loro": "70 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (time)": {
       "yjs": "75 ms",
       "ywasm": "283 ms",
       "automerge-wasm": "30 ms",
       "automerge": "2726 ms",
-      "loro": "154 ms"
+      "loro": "233 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (updateSize)": {
       "yjs": "52743 bytes",
@@ -796,42 +796,42 @@
       "ywasm": "1 ms",
       "automerge-wasm": "11 ms",
       "automerge": "18 ms",
-      "loro": "9 ms"
+      "loro": "8 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (docSize)": {
       "yjs": "26588 bytes",
       "ywasm": "26585 bytes",
       "automerge-wasm": "86507 bytes",
       "automerge": "96446 bytes",
-      "loro": "31098 bytes"
+      "loro": "31093 bytes"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (memUsed)": {
       "yjs": "720.9 kB",
       "ywasm": "5.5 kB",
       "automerge-wasm": "248 B",
       "automerge": "38.2 kB",
-      "loro": "0 B"
+      "loro": "472 B"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (parseTime)": {
       "yjs": "76 ms",
       "ywasm": "76 ms",
       "automerge-wasm": "57 ms",
       "automerge": "59 ms",
-      "loro": "52 ms"
+      "loro": "38 ms"
     },
     "[B4] Apply real-world editing dataset (time)": {
       "yjs": "1803 ms",
       "ywasm": "43943 ms",
       "automerge-wasm": "725 ms",
       "automerge": "12746 ms",
-      "loro": "191 ms"
+      "loro": "2960 ms"
     },
     "[B4] Apply real-world editing dataset (encodeTime)": {
       "yjs": "12 ms",
       "ywasm": "4 ms",
       "automerge-wasm": "110 ms",
       "automerge": "219 ms",
-      "loro": "49 ms"
+      "loro": "75 ms"
     },
     "[B4] Apply real-world editing dataset (docSize)": {
       "yjs": "159929 bytes",
@@ -845,7 +845,7 @@
       "ywasm": "17 ms",
       "automerge-wasm": "403 ms",
       "automerge": "2115 ms",
-      "loro": "8 ms"
+      "loro": "13 ms"
     },
     "[B4] Apply real-world editing dataset (memUsed)": {
       "yjs": "3.5 MB",
@@ -857,12 +857,12 @@
     "[B4x100] Apply real-world editing dataset 100 times (time)": {
       "yjs": "199319 ms",
       "ywasm": "2732719 ms",
-      "loro": "20540 ms"
+      "loro": "300508 ms"
     },
     "[B4x100] Apply real-world editing dataset 100 times (encodeTime)": {
       "yjs": "388 ms",
       "ywasm": "209 ms",
-      "loro": "9445 ms"
+      "loro": "14360 ms"
     },
     "[B4x100] Apply real-world editing dataset 100 times (docSize)": {
       "yjs": "15989245 bytes",
@@ -872,12 +872,12 @@
     "[B4x100] Apply real-world editing dataset 100 times (parseTime)": {
       "yjs": "2183 ms",
       "ywasm": "1564 ms",
-      "loro": "852 ms"
+      "loro": "1317 ms"
     },
     "[B4x100] Apply real-world editing dataset 100 times (memUsed)": {
       "yjs": "352.9 MB",
       "ywasm": "0 B",
-      "loro": "2.8 kB"
+      "loro": "2.1 kB"
     }
   }
 }

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -5,28 +5,28 @@
       "ywasm": "0.9.3",
       "automerge-wasm": "0.9.0",
       "automerge": "2.1.10",
-      "loro": "0.10.0"
+      "loro": "0.10.1"
     },
     "Bundle size": {
       "yjs": "80413 bytes",
       "ywasm": "677652 bytes",
       "automerge-wasm": "1695301 bytes",
       "automerge": "1737571 bytes",
-      "loro": "1059834 bytes"
+      "loro": "1052250 bytes"
     },
     "Bundle size (gzipped)": {
       "yjs": "23571 bytes",
       "ywasm": "213832 bytes",
       "automerge-wasm": "592235 bytes",
       "automerge": "604118 bytes",
-      "loro": "401549 bytes"
+      "loro": "399686 bytes"
     },
     "[B1.1] Append N characters (time)": {
       "yjs": "164 ms",
       "ywasm": "135 ms",
       "automerge-wasm": "117 ms",
       "automerge": "364 ms",
-      "loro": "126 ms"
+      "loro": "218 ms"
     },
     "[B1.1] Append N characters (avgUpdateSize)": {
       "yjs": "27 bytes",
@@ -47,21 +47,21 @@
       "ywasm": "6031 bytes",
       "automerge-wasm": "3992 bytes",
       "automerge": "3992 bytes",
-      "loro": "6152 bytes"
+      "loro": "6162 bytes"
     },
     "[B1.1] Append N characters (memUsed)": {
       "yjs": "0 B",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "0 B"
+      "loro": "353.1 kB"
     },
     "[B1.1] Append N characters (parseTime)": {
       "yjs": "46 ms",
       "ywasm": "43 ms",
       "automerge-wasm": "91 ms",
       "automerge": "95 ms",
-      "loro": "38 ms"
+      "loro": "45 ms"
     },
     "[B1.2] Insert string of length N (time)": {
       "yjs": "1 ms",
@@ -89,28 +89,28 @@
       "ywasm": "6031 bytes",
       "automerge-wasm": "3974 bytes",
       "automerge": "3974 bytes",
-      "loro": "6107 bytes"
+      "loro": "6117 bytes"
     },
     "[B1.2] Insert string of length N (memUsed)": {
       "yjs": "192.4 kB",
       "ywasm": "424.3 kB",
       "automerge-wasm": "840 B",
       "automerge": "9.2 kB",
-      "loro": "132 kB"
+      "loro": "0 B"
     },
     "[B1.2] Insert string of length N (parseTime)": {
       "yjs": "56 ms",
       "ywasm": "44 ms",
       "automerge-wasm": "53 ms",
       "automerge": "43 ms",
-      "loro": "43 ms"
+      "loro": "40 ms"
     },
     "[B1.3] Prepend N characters (time)": {
       "yjs": "132 ms",
       "ywasm": "21 ms",
       "automerge-wasm": "86 ms",
       "automerge": "314 ms",
-      "loro": "85 ms"
+      "loro": "49 ms"
     },
     "[B1.3] Prepend N characters (avgUpdateSize)": {
       "yjs": "27 bytes",
@@ -124,14 +124,14 @@
       "ywasm": "0 ms",
       "automerge-wasm": "5 ms",
       "automerge": "5 ms",
-      "loro": "2 ms"
+      "loro": "16 ms"
     },
     "[B1.3] Prepend N characters (docSize)": {
       "yjs": "6041 bytes",
       "ywasm": "6041 bytes",
       "automerge-wasm": "3988 bytes",
       "automerge": "3988 bytes",
-      "loro": "12114 bytes"
+      "loro": "12125 bytes"
     },
     "[B1.3] Prepend N characters (memUsed)": {
       "yjs": "1.2 MB",
@@ -145,14 +145,14 @@
       "ywasm": "50 ms",
       "automerge-wasm": "90 ms",
       "automerge": "96 ms",
-      "loro": "69 ms"
+      "loro": "54 ms"
     },
     "[B1.4] Insert N characters at random positions (time)": {
       "yjs": "145 ms",
       "ywasm": "130 ms",
       "automerge-wasm": "105 ms",
       "automerge": "314 ms",
-      "loro": "84 ms"
+      "loro": "39 ms"
     },
     "[B1.4] Insert N characters at random positions (avgUpdateSize)": {
       "yjs": "29 bytes",
@@ -166,14 +166,14 @@
       "ywasm": "1 ms",
       "automerge-wasm": "8 ms",
       "automerge": "9 ms",
-      "loro": "2 ms"
+      "loro": "23 ms"
     },
     "[B1.4] Insert N characters at random positions (docSize)": {
       "yjs": "29554 bytes",
       "ywasm": "29554 bytes",
       "automerge-wasm": "24743 bytes",
       "automerge": "24743 bytes",
-      "loro": "23527 bytes"
+      "loro": "35401 bytes"
     },
     "[B1.4] Insert N characters at random positions (memUsed)": {
       "yjs": "1.1 MB",
@@ -187,14 +187,14 @@
       "ywasm": "43 ms",
       "automerge-wasm": "105 ms",
       "automerge": "106 ms",
-      "loro": "63 ms"
+      "loro": "33 ms"
     },
     "[B1.5] Insert N words at random positions (time)": {
       "yjs": "166 ms",
       "ywasm": "438 ms",
       "automerge-wasm": "326 ms",
       "automerge": "515 ms",
-      "loro": "87 ms"
+      "loro": "38 ms"
     },
     "[B1.5] Insert N words at random positions (avgUpdateSize)": {
       "yjs": "36 bytes",
@@ -208,14 +208,14 @@
       "ywasm": "1 ms",
       "automerge-wasm": "21 ms",
       "automerge": "23 ms",
-      "loro": "2 ms"
+      "loro": "46 ms"
     },
     "[B1.5] Insert N words at random positions (docSize)": {
       "yjs": "87924 bytes",
       "ywasm": "87924 bytes",
       "automerge-wasm": "96203 bytes",
       "automerge": "96203 bytes",
-      "loro": "62296 bytes"
+      "loro": "94524 bytes"
     },
     "[B1.5] Insert N words at random positions (memUsed)": {
       "yjs": "2.3 MB",
@@ -229,14 +229,14 @@
       "ywasm": "48 ms",
       "automerge-wasm": "147 ms",
       "automerge": "171 ms",
-      "loro": "79 ms"
+      "loro": "31 ms"
     },
     "[B1.6] Insert string, then delete it (time)": {
       "yjs": "2 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "24 ms",
       "automerge": "24 ms",
-      "loro": "2 ms"
+      "loro": "1 ms"
     },
     "[B1.6] Insert string, then delete it (avgUpdateSize)": {
       "yjs": "6053 bytes",
@@ -257,7 +257,7 @@
       "ywasm": "38 bytes",
       "automerge-wasm": "3993 bytes",
       "automerge": "3993 bytes",
-      "loro": "6114 bytes"
+      "loro": "6120 bytes"
     },
     "[B1.6] Insert string, then delete it (memUsed)": {
       "yjs": "65.7 kB",
@@ -271,14 +271,14 @@
       "ywasm": "43 ms",
       "automerge-wasm": "54 ms",
       "automerge": "67 ms",
-      "loro": "38 ms"
+      "loro": "29 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (time)": {
       "yjs": "171 ms",
       "ywasm": "137 ms",
       "automerge-wasm": "247 ms",
       "automerge": "462 ms",
-      "loro": "107 ms"
+      "loro": "46 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (avgUpdateSize)": {
       "yjs": "31 bytes",
@@ -292,14 +292,14 @@
       "ywasm": "1 ms",
       "automerge-wasm": "20 ms",
       "automerge": "21 ms",
-      "loro": "2 ms"
+      "loro": "11 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (docSize)": {
       "yjs": "28377 bytes",
       "ywasm": "28377 bytes",
       "automerge-wasm": "59281 bytes",
       "automerge": "59281 bytes",
-      "loro": "47181 bytes"
+      "loro": "50836 bytes"
     },
     "[B1.7] Insert/Delete strings at random positions (memUsed)": {
       "yjs": "1.2 MB",
@@ -313,14 +313,14 @@
       "ywasm": "46 ms",
       "automerge-wasm": "131 ms",
       "automerge": "136 ms",
-      "loro": "74 ms"
+      "loro": "27 ms"
     },
     "[B1.8] Append N numbers (time)": {
       "yjs": "160 ms",
       "ywasm": "26 ms",
       "automerge-wasm": "120 ms",
       "automerge": "455 ms",
-      "loro": "89 ms"
+      "loro": "41 ms"
     },
     "[B1.8] Append N numbers (avgUpdateSize)": {
       "yjs": "32 bytes",
@@ -341,7 +341,7 @@
       "ywasm": "35634 bytes",
       "automerge-wasm": "26985 bytes",
       "automerge": "26985 bytes",
-      "loro": "35712 bytes"
+      "loro": "35719 bytes"
     },
     "[B1.8] Append N numbers (memUsed)": {
       "yjs": "0 B",
@@ -355,14 +355,14 @@
       "ywasm": "43 ms",
       "automerge-wasm": "97 ms",
       "automerge": "101 ms",
-      "loro": "38 ms"
+      "loro": "33 ms"
     },
     "[B1.9] Insert Array of N numbers (time)": {
       "yjs": "5 ms",
       "ywasm": "3 ms",
       "automerge-wasm": "8 ms",
       "automerge": "40 ms",
-      "loro": "7 ms"
+      "loro": "9 ms"
     },
     "[B1.9] Insert Array of N numbers (avgUpdateSize)": {
       "yjs": "35657 bytes",
@@ -383,28 +383,28 @@
       "ywasm": "35657 bytes",
       "automerge-wasm": "26953 bytes",
       "automerge": "26953 bytes",
-      "loro": "35735 bytes"
+      "loro": "35742 bytes"
     },
     "[B1.9] Insert Array of N numbers (memUsed)": {
       "yjs": "45.6 kB",
       "ywasm": "552 B",
       "automerge-wasm": "344 B",
       "automerge": "37.9 kB",
-      "loro": "2.5 kB"
+      "loro": "0 B"
     },
     "[B1.9] Insert Array of N numbers (parseTime)": {
       "yjs": "58 ms",
       "ywasm": "42 ms",
       "automerge-wasm": "57 ms",
       "automerge": "68 ms",
-      "loro": "40 ms"
+      "loro": "28 ms"
     },
     "[B1.10] Prepend N numbers (time)": {
       "yjs": "129 ms",
       "ywasm": "27 ms",
       "automerge-wasm": "214 ms",
       "automerge": "530 ms",
-      "loro": "87 ms"
+      "loro": "40 ms"
     },
     "[B1.10] Prepend N numbers (avgUpdateSize)": {
       "yjs": "32 bytes",
@@ -418,14 +418,14 @@
       "ywasm": "1 ms",
       "automerge-wasm": "9 ms",
       "automerge": "8 ms",
-      "loro": "2 ms"
+      "loro": "6 ms"
     },
     "[B1.10] Prepend N numbers (docSize)": {
       "yjs": "35665 bytes",
       "ywasm": "65658 bytes",
       "automerge-wasm": "26987 bytes",
       "automerge": "26987 bytes",
-      "loro": "41740 bytes"
+      "loro": "41748 bytes"
     },
     "[B1.10] Prepend N numbers (memUsed)": {
       "yjs": "1.9 MB",
@@ -439,14 +439,14 @@
       "ywasm": "45 ms",
       "automerge-wasm": "98 ms",
       "automerge": "106 ms",
-      "loro": "59 ms"
+      "loro": "28 ms"
     },
     "[B1.11] Insert N numbers at random positions (time)": {
       "yjs": "144 ms",
       "ywasm": "149 ms",
       "automerge-wasm": "130 ms",
       "automerge": "470 ms",
-      "loro": "78 ms"
+      "loro": "39 ms"
     },
     "[B1.11] Insert N numbers at random positions (avgUpdateSize)": {
       "yjs": "34 bytes",
@@ -460,14 +460,14 @@
       "ywasm": "1 ms",
       "automerge-wasm": "9 ms",
       "automerge": "11 ms",
-      "loro": "6 ms"
+      "loro": "24 ms"
     },
     "[B1.11] Insert N numbers at random positions (docSize)": {
       "yjs": "59137 bytes",
       "ywasm": "59152 bytes",
       "automerge-wasm": "47746 bytes",
       "automerge": "47746 bytes",
-      "loro": "53145 bytes"
+      "loro": "65016 bytes"
     },
     "[B1.11] Insert N numbers at random positions (memUsed)": {
       "yjs": "2.1 MB",
@@ -481,7 +481,7 @@
       "ywasm": "51 ms",
       "automerge-wasm": "127 ms",
       "automerge": "104 ms",
-      "loro": "74 ms"
+      "loro": "28 ms"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (time)": {
       "yjs": "3 ms",
@@ -495,7 +495,7 @@
       "ywasm": "6094 bytes",
       "automerge-wasm": "9499 bytes",
       "automerge": "9499 bytes",
-      "loro": "6218 bytes"
+      "loro": "9276 bytes"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (encodeTime)": {
       "yjs": "0 ms",
@@ -509,49 +509,49 @@
       "ywasm": "12152 bytes",
       "automerge-wasm": "8011 bytes",
       "automerge": "8011 bytes",
-      "loro": "12237 bytes"
+      "loro": "12248 bytes"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (memUsed)": {
       "yjs": "76.2 kB",
       "ywasm": "304 B",
       "automerge-wasm": "864 B",
       "automerge": "14.5 kB",
-      "loro": "1.8 kB"
+      "loro": "1.9 kB"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (parseTime)": {
       "yjs": "62 ms",
       "ywasm": "41 ms",
       "automerge-wasm": "55 ms",
       "automerge": "64 ms",
-      "loro": "39 ms"
+      "loro": "28 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (time)": {
       "yjs": "72 ms",
       "ywasm": "405 ms",
       "automerge-wasm": "677 ms",
       "automerge": "311 ms",
-      "loro": "78 ms"
+      "loro": "204 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (updateSize)": {
       "yjs": "33444 bytes",
       "ywasm": "177007 bytes",
       "automerge-wasm": "1093293 bytes",
       "automerge": "27476 bytes",
-      "loro": "23735 bytes"
+      "loro": "665563 bytes"
     },
     "[B2.2] Concurrently insert N characters at random positions (encodeTime)": {
       "yjs": "2 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "17 ms",
       "automerge": "10 ms",
-      "loro": "3 ms"
+      "loro": "57 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (docSize)": {
       "yjs": "66860 bytes",
       "ywasm": "66852 bytes",
       "automerge-wasm": "50705 bytes",
       "automerge": "50683 bytes",
-      "loro": "47273 bytes"
+      "loro": "71858 bytes"
     },
     "[B2.2] Concurrently insert N characters at random positions (memUsed)": {
       "yjs": "2.4 MB",
@@ -565,35 +565,35 @@
       "ywasm": "52 ms",
       "automerge-wasm": "151 ms",
       "automerge": "67 ms",
-      "loro": "91 ms"
+      "loro": "53 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (time)": {
       "yjs": "86 ms",
       "ywasm": "1046 ms",
       "automerge-wasm": "1050 ms",
       "automerge": "701 ms",
-      "loro": "110 ms"
+      "loro": "213 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (updateSize)": {
       "yjs": "88994 bytes",
       "ywasm": "215213 bytes",
       "automerge-wasm": "1185202 bytes",
       "automerge": "122485 bytes",
-      "loro": "62098 bytes"
+      "loro": "731420 bytes"
     },
     "[B2.3] Concurrently insert N words at random positions (encodeTime)": {
       "yjs": "4 ms",
       "ywasm": "4 ms",
       "automerge-wasm": "59 ms",
       "automerge": "37 ms",
-      "loro": "3 ms"
+      "loro": "98 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (docSize)": {
       "yjs": "178137 bytes",
       "ywasm": "178137 bytes",
       "automerge-wasm": "191497 bytes",
       "automerge": "185019 bytes",
-      "loro": "123997 bytes"
+      "loro": "188458 bytes"
     },
     "[B2.3] Concurrently insert N words at random positions (memUsed)": {
       "yjs": "5.6 MB",
@@ -607,35 +607,35 @@
       "ywasm": "73 ms",
       "automerge-wasm": "317 ms",
       "automerge": "190 ms",
-      "loro": "138 ms"
+      "loro": "49 ms"
     },
     "[B2.4] Concurrently insert & delete (time)": {
       "yjs": "232 ms",
       "ywasm": "2740 ms",
       "automerge-wasm": "2564 ms",
       "automerge": "1113 ms",
-      "loro": "205 ms"
+      "loro": "427 ms"
     },
     "[B2.4] Concurrently insert & delete (updateSize)": {
       "yjs": "139517 bytes",
       "ywasm": "398881 bytes",
       "automerge-wasm": "2395876 bytes",
       "automerge": "298810 bytes",
-      "loro": "109161 bytes"
+      "loro": "1441427 bytes"
     },
     "[B2.4] Concurrently insert & delete (encodeTime)": {
       "yjs": "21 ms",
       "ywasm": "7 ms",
       "automerge-wasm": "76 ms",
       "automerge": "62 ms",
-      "loro": "9 ms"
+      "loro": "155 ms"
     },
     "[B2.4] Concurrently insert & delete (docSize)": {
       "yjs": "279172 bytes",
       "ywasm": "279172 bytes",
       "automerge-wasm": "307291 bytes",
       "automerge": "293829 bytes",
-      "loro": "218118 bytes"
+      "loro": "289590 bytes"
     },
     "[B2.4] Concurrently insert & delete (memUsed)": {
       "yjs": "9.4 MB",
@@ -649,14 +649,14 @@
       "ywasm": "84 ms",
       "automerge-wasm": "434 ms",
       "automerge": "278 ms",
-      "loro": "204 ms"
+      "loro": "53 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (time)": {
       "yjs": "91 ms",
       "ywasm": "276 ms",
       "automerge-wasm": "34 ms",
       "automerge": "1616 ms",
-      "loro": "1891 ms"
+      "loro": "43 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (updateSize)": {
       "yjs": "49181 bytes",
@@ -670,35 +670,35 @@
       "ywasm": "2 ms",
       "automerge-wasm": "20 ms",
       "automerge": "12 ms",
-      "loro": "1 ms"
+      "loro": "3 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (docSize)": {
       "yjs": "32246 bytes",
       "ywasm": "32213 bytes",
       "automerge-wasm": "86168 bytes",
       "automerge": "86170 bytes",
-      "loro": "21487 bytes"
+      "loro": "21506 bytes"
     },
     "[B3.1] 20√N clients concurrently set number in Map (memUsed)": {
       "yjs": "196.3 kB",
       "ywasm": "272 B",
       "automerge-wasm": "480 B",
       "automerge": "0 B",
-      "loro": "144 B"
+      "loro": "0 B"
     },
     "[B3.1] 20√N clients concurrently set number in Map (parseTime)": {
       "yjs": "100 ms",
       "ywasm": "77 ms",
       "automerge-wasm": "77 ms",
       "automerge": "48 ms",
-      "loro": "44 ms"
+      "loro": "46 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (time)": {
       "yjs": "84 ms",
       "ywasm": "284 ms",
       "automerge-wasm": "45 ms",
       "automerge": "1727 ms",
-      "loro": "2030 ms"
+      "loro": "50 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (updateSize)": {
       "yjs": "85082 bytes",
@@ -719,28 +719,28 @@
       "ywasm": "32218 bytes",
       "automerge-wasm": "93420 bytes",
       "automerge": "112588 bytes",
-      "loro": "40475 bytes"
+      "loro": "40494 bytes"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (memUsed)": {
       "yjs": "232.4 kB",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "312 B"
+      "loro": "584 B"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (parseTime)": {
       "yjs": "93 ms",
       "ywasm": "75 ms",
       "automerge-wasm": "100 ms",
       "automerge": "93 ms",
-      "loro": "96 ms"
+      "loro": "75 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (time)": {
       "yjs": "88 ms",
       "ywasm": "299 ms",
       "automerge-wasm": "232 ms",
       "automerge": "2644 ms",
-      "loro": "2037 ms"
+      "loro": "115 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (updateSize)": {
       "yjs": "7826225 bytes",
@@ -754,35 +754,35 @@
       "ywasm": "1 ms",
       "automerge-wasm": "96 ms",
       "automerge": "105 ms",
-      "loro": "45 ms"
+      "loro": "46 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (docSize)": {
       "yjs": "38370 bytes",
       "ywasm": "35296 bytes",
       "automerge-wasm": "97995 bytes",
       "automerge": "98003 bytes",
-      "loro": "7799167 bytes"
+      "loro": "7798572 bytes"
     },
     "[B3.3] 20√N clients concurrently set String in Map (memUsed)": {
       "yjs": "179.2 kB",
       "ywasm": "200 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "656 B"
+      "loro": "488 B"
     },
     "[B3.3] 20√N clients concurrently set String in Map (parseTime)": {
       "yjs": "104 ms",
       "ywasm": "86 ms",
       "automerge-wasm": "123 ms",
       "automerge": "130 ms",
-      "loro": "74 ms"
+      "loro": "51 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (time)": {
       "yjs": "75 ms",
       "ywasm": "283 ms",
       "automerge-wasm": "30 ms",
       "automerge": "2726 ms",
-      "loro": "107643 ms"
+      "loro": "154 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (updateSize)": {
       "yjs": "52743 bytes",
@@ -796,56 +796,56 @@
       "ywasm": "1 ms",
       "automerge-wasm": "11 ms",
       "automerge": "18 ms",
-      "loro": "2 ms"
+      "loro": "9 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (docSize)": {
       "yjs": "26588 bytes",
       "ywasm": "26585 bytes",
       "automerge-wasm": "86507 bytes",
       "automerge": "96446 bytes",
-      "loro": "28140 bytes"
+      "loro": "31098 bytes"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (memUsed)": {
       "yjs": "720.9 kB",
       "ywasm": "5.5 kB",
       "automerge-wasm": "248 B",
       "automerge": "38.2 kB",
-      "loro": "6.1 kB"
+      "loro": "0 B"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (parseTime)": {
       "yjs": "76 ms",
       "ywasm": "76 ms",
       "automerge-wasm": "57 ms",
       "automerge": "59 ms",
-      "loro": "254 ms"
+      "loro": "52 ms"
     },
     "[B4] Apply real-world editing dataset (time)": {
       "yjs": "1803 ms",
       "ywasm": "43943 ms",
       "automerge-wasm": "725 ms",
       "automerge": "12746 ms",
-      "loro": "1198 ms"
+      "loro": "191 ms"
     },
     "[B4] Apply real-world editing dataset (encodeTime)": {
       "yjs": "12 ms",
       "ywasm": "4 ms",
       "automerge-wasm": "110 ms",
       "automerge": "219 ms",
-      "loro": "7 ms"
+      "loro": "49 ms"
     },
     "[B4] Apply real-world editing dataset (docSize)": {
       "yjs": "159929 bytes",
       "ywasm": "159929 bytes",
       "automerge-wasm": "129095 bytes",
       "automerge": "129116 bytes",
-      "loro": "229732 bytes"
+      "loro": "258228 bytes"
     },
     "[B4] Apply real-world editing dataset (parseTime)": {
       "yjs": "38 ms",
       "ywasm": "17 ms",
       "automerge-wasm": "403 ms",
       "automerge": "2115 ms",
-      "loro": "74 ms"
+      "loro": "8 ms"
     },
     "[B4] Apply real-world editing dataset (memUsed)": {
       "yjs": "3.5 MB",
@@ -856,23 +856,28 @@
     },
     "[B4x100] Apply real-world editing dataset 100 times (time)": {
       "yjs": "199319 ms",
-      "ywasm": "2732719 ms"
+      "ywasm": "2732719 ms",
+      "loro": "20540 ms"
     },
     "[B4x100] Apply real-world editing dataset 100 times (encodeTime)": {
       "yjs": "388 ms",
-      "ywasm": "209 ms"
+      "ywasm": "209 ms",
+      "loro": "9445 ms"
     },
     "[B4x100] Apply real-world editing dataset 100 times (docSize)": {
       "yjs": "15989245 bytes",
-      "ywasm": "15989245 bytes"
+      "ywasm": "15989245 bytes",
+      "loro": "25805795 bytes"
     },
     "[B4x100] Apply real-world editing dataset 100 times (parseTime)": {
       "yjs": "2183 ms",
-      "ywasm": "1564 ms"
+      "ywasm": "1564 ms",
+      "loro": "852 ms"
     },
     "[B4x100] Apply real-world editing dataset 100 times (memUsed)": {
       "yjs": "352.9 MB",
-      "ywasm": "0 B"
+      "ywasm": "0 B",
+      "loro": "2.8 kB"
     }
   }
 }

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -8,25 +8,25 @@
       "loro": "0.10.1"
     },
     "Bundle size": {
-      "yjs": "128226 bytes",
-      "ywasm": "677652 bytes",
-      "automerge-wasm": "1695301 bytes",
+      "yjs": "53755 bytes",
+      "ywasm": "677667 bytes",
+      "automerge-wasm": "1695062 bytes",
       "automerge": "1737571 bytes",
       "loro": "1052250 bytes"
     },
     "Bundle size (gzipped)": {
       "yjs": "38816 bytes",
-      "ywasm": "213832 bytes",
-      "automerge-wasm": "592235 bytes",
+      "ywasm": "213833 bytes",
+      "automerge-wasm": "592220 bytes",
       "automerge": "604118 bytes",
       "loro": "399276 bytes"
     },
     "[B1.1] Append N characters (time)": {
-      "yjs": "164 ms",
-      "ywasm": "135 ms",
-      "automerge-wasm": "117 ms",
-      "automerge": "364 ms",
-      "loro": "119 ms"
+      "yjs": "188 ms",
+      "ywasm": "154 ms",
+      "automerge-wasm": "119 ms",
+      "automerge": "365 ms",
+      "loro": "120 ms"
     },
     "[B1.1] Append N characters (avgUpdateSize)": {
       "yjs": "27 bytes",
@@ -38,7 +38,7 @@
     "[B1.1] Append N characters (encodeTime)": {
       "yjs": "1 ms",
       "ywasm": "1 ms",
-      "automerge-wasm": "7 ms",
+      "automerge-wasm": "6 ms",
       "automerge": "7 ms",
       "loro": "1 ms"
     },
@@ -57,14 +57,14 @@
       "loro": "0 B"
     },
     "[B1.1] Append N characters (parseTime)": {
-      "yjs": "46 ms",
-      "ywasm": "43 ms",
-      "automerge-wasm": "91 ms",
-      "automerge": "95 ms",
-      "loro": "39 ms"
+      "yjs": "32 ms",
+      "ywasm": "23 ms",
+      "automerge-wasm": "79 ms",
+      "automerge": "80 ms",
+      "loro": "26 ms"
     },
     "[B1.2] Insert string of length N (time)": {
-      "yjs": "1 ms",
+      "yjs": "0 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "8 ms",
       "automerge": "9 ms",
@@ -78,7 +78,7 @@
       "loro": "6107 bytes"
     },
     "[B1.2] Insert string of length N (encodeTime)": {
-      "yjs": "1 ms",
+      "yjs": "0 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "3 ms",
       "automerge": "3 ms",
@@ -92,25 +92,25 @@
       "loro": "6117 bytes"
     },
     "[B1.2] Insert string of length N (memUsed)": {
-      "yjs": "192.4 kB",
-      "ywasm": "424.3 kB",
-      "automerge-wasm": "840 B",
-      "automerge": "9.2 kB",
-      "loro": "13.2 kB"
+      "yjs": "17.4 kB",
+      "ywasm": "0 B",
+      "automerge-wasm": "712 B",
+      "automerge": "8.8 kB",
+      "loro": "0 B"
     },
     "[B1.2] Insert string of length N (parseTime)": {
-      "yjs": "56 ms",
-      "ywasm": "44 ms",
-      "automerge-wasm": "53 ms",
-      "automerge": "43 ms",
-      "loro": "42 ms"
+      "yjs": "27 ms",
+      "ywasm": "34 ms",
+      "automerge-wasm": "32 ms",
+      "automerge": "47 ms",
+      "loro": "29 ms"
     },
     "[B1.3] Prepend N characters (time)": {
-      "yjs": "132 ms",
-      "ywasm": "21 ms",
-      "automerge-wasm": "86 ms",
-      "automerge": "314 ms",
-      "loro": "75 ms"
+      "yjs": "119 ms",
+      "ywasm": "23 ms",
+      "automerge-wasm": "87 ms",
+      "automerge": "307 ms",
+      "loro": "81 ms"
     },
     "[B1.3] Prepend N characters (avgUpdateSize)": {
       "yjs": "27 bytes",
@@ -122,7 +122,7 @@
     "[B1.3] Prepend N characters (encodeTime)": {
       "yjs": "3 ms",
       "ywasm": "0 ms",
-      "automerge-wasm": "5 ms",
+      "automerge-wasm": "6 ms",
       "automerge": "5 ms",
       "loro": "10 ms"
     },
@@ -134,25 +134,25 @@
       "loro": "12125 bytes"
     },
     "[B1.3] Prepend N characters (memUsed)": {
-      "yjs": "1.2 MB",
+      "yjs": "919.9 kB",
       "ywasm": "8.3 kB",
-      "automerge-wasm": "7.9 kB",
+      "automerge-wasm": "1.1 kB",
       "automerge": "0 B",
-      "loro": "7.7 kB"
+      "loro": "26.3 kB"
     },
     "[B1.3] Prepend N characters (parseTime)": {
-      "yjs": "85 ms",
-      "ywasm": "50 ms",
-      "automerge-wasm": "90 ms",
-      "automerge": "96 ms",
-      "loro": "41 ms"
+      "yjs": "93 ms",
+      "ywasm": "31 ms",
+      "automerge-wasm": "60 ms",
+      "automerge": "63 ms",
+      "loro": "26 ms"
     },
     "[B1.4] Insert N characters at random positions (time)": {
-      "yjs": "145 ms",
-      "ywasm": "130 ms",
-      "automerge-wasm": "105 ms",
-      "automerge": "314 ms",
-      "loro": "74 ms"
+      "yjs": "131 ms",
+      "ywasm": "128 ms",
+      "automerge-wasm": "100 ms",
+      "automerge": "310 ms",
+      "loro": "79 ms"
     },
     "[B1.4] Insert N characters at random positions (avgUpdateSize)": {
       "yjs": "29 bytes",
@@ -162,10 +162,10 @@
       "loro": "109 bytes"
     },
     "[B1.4] Insert N characters at random positions (encodeTime)": {
-      "yjs": "7 ms",
+      "yjs": "1 ms",
       "ywasm": "1 ms",
-      "automerge-wasm": "8 ms",
-      "automerge": "9 ms",
+      "automerge-wasm": "7 ms",
+      "automerge": "8 ms",
       "loro": "35 ms"
     },
     "[B1.4] Insert N characters at random positions (docSize)": {
@@ -176,25 +176,25 @@
       "loro": "35401 bytes"
     },
     "[B1.4] Insert N characters at random positions (memUsed)": {
-      "yjs": "1.1 MB",
+      "yjs": "883.6 kB",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "9.5 kB",
-      "loro": "7.9 kB"
+      "automerge": "9 kB",
+      "loro": "0 B"
     },
     "[B1.4] Insert N characters at random positions (parseTime)": {
-      "yjs": "90 ms",
-      "ywasm": "43 ms",
-      "automerge-wasm": "105 ms",
-      "automerge": "106 ms",
-      "loro": "40 ms"
+      "yjs": "76 ms",
+      "ywasm": "29 ms",
+      "automerge-wasm": "79 ms",
+      "automerge": "79 ms",
+      "loro": "31 ms"
     },
     "[B1.5] Insert N words at random positions (time)": {
-      "yjs": "166 ms",
-      "ywasm": "438 ms",
-      "automerge-wasm": "326 ms",
-      "automerge": "515 ms",
-      "loro": "76 ms"
+      "yjs": "154 ms",
+      "ywasm": "449 ms",
+      "automerge-wasm": "230 ms",
+      "automerge": "449 ms",
+      "loro": "82 ms"
     },
     "[B1.5] Insert N words at random positions (avgUpdateSize)": {
       "yjs": "36 bytes",
@@ -204,10 +204,10 @@
       "loro": "117 bytes"
     },
     "[B1.5] Insert N words at random positions (encodeTime)": {
-      "yjs": "10 ms",
+      "yjs": "5 ms",
       "ywasm": "1 ms",
-      "automerge-wasm": "21 ms",
-      "automerge": "23 ms",
+      "automerge-wasm": "23 ms",
+      "automerge": "21 ms",
       "loro": "69 ms"
     },
     "[B1.5] Insert N words at random positions (docSize)": {
@@ -219,24 +219,24 @@
     },
     "[B1.5] Insert N words at random positions (memUsed)": {
       "yjs": "2.3 MB",
-      "ywasm": "720 B",
+      "ywasm": "872 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "2.4 kB"
+      "loro": "2.1 kB"
     },
     "[B1.5] Insert N words at random positions (parseTime)": {
-      "yjs": "74 ms",
-      "ywasm": "48 ms",
-      "automerge-wasm": "147 ms",
-      "automerge": "171 ms",
-      "loro": "45 ms"
+      "yjs": "92 ms",
+      "ywasm": "34 ms",
+      "automerge-wasm": "143 ms",
+      "automerge": "143 ms",
+      "loro": "31 ms"
     },
     "[B1.6] Insert string, then delete it (time)": {
-      "yjs": "2 ms",
+      "yjs": "1 ms",
       "ywasm": "1 ms",
-      "automerge-wasm": "24 ms",
-      "automerge": "24 ms",
-      "loro": "1 ms"
+      "automerge-wasm": "22 ms",
+      "automerge": "22 ms",
+      "loro": "2 ms"
     },
     "[B1.6] Insert string, then delete it (avgUpdateSize)": {
       "yjs": "6053 bytes",
@@ -249,7 +249,7 @@
       "yjs": "0 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "4 ms",
-      "automerge": "4 ms",
+      "automerge": "3 ms",
       "loro": "0 ms"
     },
     "[B1.6] Insert string, then delete it (docSize)": {
@@ -260,25 +260,25 @@
       "loro": "6120 bytes"
     },
     "[B1.6] Insert string, then delete it (memUsed)": {
-      "yjs": "65.7 kB",
+      "yjs": "0 B",
       "ywasm": "0 B",
-      "automerge-wasm": "584 B",
-      "automerge": "2.2 kB",
-      "loro": "2.6 kB"
+      "automerge-wasm": "352 B",
+      "automerge": "2 kB",
+      "loro": "0 B"
     },
     "[B1.6] Insert string, then delete it (parseTime)": {
-      "yjs": "59 ms",
-      "ywasm": "43 ms",
-      "automerge-wasm": "54 ms",
-      "automerge": "67 ms",
-      "loro": "38 ms"
+      "yjs": "44 ms",
+      "ywasm": "28 ms",
+      "automerge-wasm": "40 ms",
+      "automerge": "37 ms",
+      "loro": "27 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (time)": {
-      "yjs": "171 ms",
-      "ywasm": "137 ms",
-      "automerge-wasm": "247 ms",
-      "automerge": "462 ms",
-      "loro": "92 ms"
+      "yjs": "158 ms",
+      "ywasm": "141 ms",
+      "automerge-wasm": "186 ms",
+      "automerge": "389 ms",
+      "loro": "98 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (avgUpdateSize)": {
       "yjs": "31 bytes",
@@ -290,8 +290,8 @@
     "[B1.7] Insert/Delete strings at random positions (encodeTime)": {
       "yjs": "8 ms",
       "ywasm": "1 ms",
-      "automerge-wasm": "20 ms",
-      "automerge": "21 ms",
+      "automerge-wasm": "18 ms",
+      "automerge": "19 ms",
       "loro": "17 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (docSize)": {
@@ -302,25 +302,25 @@
       "loro": "50836 bytes"
     },
     "[B1.7] Insert/Delete strings at random positions (memUsed)": {
-      "yjs": "1.2 MB",
-      "ywasm": "480 B",
+      "yjs": "1.4 MB",
+      "ywasm": "632 B",
       "automerge-wasm": "0 B",
-      "automerge": "0 B",
+      "automerge": "6 kB",
       "loro": "1.8 kB"
     },
     "[B1.7] Insert/Delete strings at random positions (parseTime)": {
-      "yjs": "93 ms",
-      "ywasm": "46 ms",
-      "automerge-wasm": "131 ms",
-      "automerge": "136 ms",
-      "loro": "40 ms"
+      "yjs": "117 ms",
+      "ywasm": "31 ms",
+      "automerge-wasm": "112 ms",
+      "automerge": "111 ms",
+      "loro": "25 ms"
     },
     "[B1.8] Append N numbers (time)": {
-      "yjs": "160 ms",
-      "ywasm": "26 ms",
-      "automerge-wasm": "120 ms",
-      "automerge": "455 ms",
-      "loro": "76 ms"
+      "yjs": "148 ms",
+      "ywasm": "29 ms",
+      "automerge-wasm": "105 ms",
+      "automerge": "480 ms",
+      "loro": "81 ms"
     },
     "[B1.8] Append N numbers (avgUpdateSize)": {
       "yjs": "32 bytes",
@@ -330,10 +330,10 @@
       "loro": "114 bytes"
     },
     "[B1.8] Append N numbers (encodeTime)": {
-      "yjs": "4 ms",
+      "yjs": "0 ms",
       "ywasm": "0 ms",
-      "automerge-wasm": "9 ms",
-      "automerge": "10 ms",
+      "automerge-wasm": "7 ms",
+      "automerge": "8 ms",
       "loro": "1 ms"
     },
     "[B1.8] Append N numbers (docSize)": {
@@ -347,22 +347,22 @@
       "yjs": "0 B",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "63.8 kB",
+      "automerge": "61.3 kB",
       "loro": "0 B"
     },
     "[B1.8] Append N numbers (parseTime)": {
-      "yjs": "66 ms",
-      "ywasm": "43 ms",
-      "automerge-wasm": "97 ms",
-      "automerge": "101 ms",
-      "loro": "37 ms"
+      "yjs": "36 ms",
+      "ywasm": "31 ms",
+      "automerge-wasm": "82 ms",
+      "automerge": "80 ms",
+      "loro": "27 ms"
     },
     "[B1.9] Insert Array of N numbers (time)": {
-      "yjs": "5 ms",
-      "ywasm": "3 ms",
+      "yjs": "1 ms",
+      "ywasm": "2 ms",
       "automerge-wasm": "8 ms",
-      "automerge": "40 ms",
-      "loro": "8 ms"
+      "automerge": "38 ms",
+      "loro": "9 ms"
     },
     "[B1.9] Insert Array of N numbers (avgUpdateSize)": {
       "yjs": "35657 bytes",
@@ -386,24 +386,24 @@
       "loro": "35742 bytes"
     },
     "[B1.9] Insert Array of N numbers (memUsed)": {
-      "yjs": "45.6 kB",
-      "ywasm": "552 B",
-      "automerge-wasm": "344 B",
-      "automerge": "37.9 kB",
-      "loro": "2.6 kB"
+      "yjs": "39.3 kB",
+      "ywasm": "608 B",
+      "automerge-wasm": "568 B",
+      "automerge": "61.6 kB",
+      "loro": "2.4 kB"
     },
     "[B1.9] Insert Array of N numbers (parseTime)": {
-      "yjs": "58 ms",
-      "ywasm": "42 ms",
-      "automerge-wasm": "57 ms",
-      "automerge": "68 ms",
-      "loro": "38 ms"
+      "yjs": "33 ms",
+      "ywasm": "26 ms",
+      "automerge-wasm": "42 ms",
+      "automerge": "53 ms",
+      "loro": "22 ms"
     },
     "[B1.10] Prepend N numbers (time)": {
-      "yjs": "129 ms",
-      "ywasm": "27 ms",
-      "automerge-wasm": "214 ms",
-      "automerge": "530 ms",
+      "yjs": "122 ms",
+      "ywasm": "28 ms",
+      "automerge-wasm": "139 ms",
+      "automerge": "461 ms",
       "loro": "78 ms"
     },
     "[B1.10] Prepend N numbers (avgUpdateSize)": {
@@ -414,11 +414,11 @@
       "loro": "113 bytes"
     },
     "[B1.10] Prepend N numbers (encodeTime)": {
-      "yjs": "6 ms",
+      "yjs": "3 ms",
       "ywasm": "1 ms",
-      "automerge-wasm": "9 ms",
-      "automerge": "8 ms",
-      "loro": "9 ms"
+      "automerge-wasm": "8 ms",
+      "automerge": "7 ms",
+      "loro": "10 ms"
     },
     "[B1.10] Prepend N numbers (docSize)": {
       "yjs": "35665 bytes",
@@ -428,70 +428,70 @@
       "loro": "41748 bytes"
     },
     "[B1.10] Prepend N numbers (memUsed)": {
-      "yjs": "1.9 MB",
-      "ywasm": "0 B",
+      "yjs": "1.8 MB",
+      "ywasm": "168 kB",
       "automerge-wasm": "0 B",
-      "automerge": "65.7 kB",
-      "loro": "249.3 kB"
+      "automerge": "61.5 kB",
+      "loro": "119.5 kB"
     },
     "[B1.10] Prepend N numbers (parseTime)": {
-      "yjs": "73 ms",
-      "ywasm": "45 ms",
-      "automerge-wasm": "98 ms",
-      "automerge": "106 ms",
-      "loro": "40 ms"
+      "yjs": "96 ms",
+      "ywasm": "31 ms",
+      "automerge-wasm": "71 ms",
+      "automerge": "77 ms",
+      "loro": "32 ms"
     },
     "[B1.11] Insert N numbers at random positions (time)": {
-      "yjs": "144 ms",
-      "ywasm": "149 ms",
-      "automerge-wasm": "130 ms",
-      "automerge": "470 ms",
+      "yjs": "134 ms",
+      "ywasm": "144 ms",
+      "automerge-wasm": "118 ms",
+      "automerge": "433 ms",
       "loro": "78 ms"
     },
     "[B1.11] Insert N numbers at random positions (avgUpdateSize)": {
-      "yjs": "34 bytes",
+      "yjs": "33 bytes",
       "ywasm": "34 bytes",
       "automerge-wasm": "125 bytes",
       "automerge": "125 bytes",
       "loro": "114 bytes"
     },
     "[B1.11] Insert N numbers at random positions (encodeTime)": {
-      "yjs": "8 ms",
+      "yjs": "1 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "9 ms",
-      "automerge": "11 ms",
-      "loro": "36 ms"
+      "automerge": "9 ms",
+      "loro": "37 ms"
     },
     "[B1.11] Insert N numbers at random positions (docSize)": {
-      "yjs": "59137 bytes",
+      "yjs": "59136 bytes",
       "ywasm": "59152 bytes",
       "automerge-wasm": "47746 bytes",
       "automerge": "47746 bytes",
       "loro": "65016 bytes"
     },
     "[B1.11] Insert N numbers at random positions (memUsed)": {
-      "yjs": "2.1 MB",
+      "yjs": "1.8 MB",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "60.1 kB",
-      "loro": "2.3 kB"
+      "automerge": "61.7 kB",
+      "loro": "0 B"
     },
     "[B1.11] Insert N numbers at random positions (parseTime)": {
-      "yjs": "93 ms",
-      "ywasm": "51 ms",
-      "automerge-wasm": "127 ms",
-      "automerge": "104 ms",
-      "loro": "44 ms"
+      "yjs": "80 ms",
+      "ywasm": "34 ms",
+      "automerge-wasm": "85 ms",
+      "automerge": "93 ms",
+      "loro": "36 ms"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (time)": {
-      "yjs": "3 ms",
+      "yjs": "1 ms",
       "ywasm": "0 ms",
-      "automerge-wasm": "51 ms",
-      "automerge": "71 ms",
-      "loro": "1 ms"
+      "automerge-wasm": "46 ms",
+      "automerge": "62 ms",
+      "loro": "2 ms"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (updateSize)": {
-      "yjs": "6093 bytes",
+      "yjs": "6094 bytes",
       "ywasm": "6094 bytes",
       "automerge-wasm": "9499 bytes",
       "automerge": "9499 bytes",
@@ -501,36 +501,36 @@
       "yjs": "0 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "6 ms",
-      "automerge": "6 ms",
+      "automerge": "5 ms",
       "loro": "0 ms"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (docSize)": {
-      "yjs": "12150 bytes",
-      "ywasm": "12152 bytes",
+      "yjs": "12152 bytes",
+      "ywasm": "12151 bytes",
       "automerge-wasm": "8011 bytes",
       "automerge": "8011 bytes",
       "loro": "12248 bytes"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (memUsed)": {
-      "yjs": "76.2 kB",
-      "ywasm": "304 B",
-      "automerge-wasm": "864 B",
+      "yjs": "0 B",
+      "ywasm": "592 B",
+      "automerge-wasm": "0 B",
       "automerge": "14.5 kB",
-      "loro": "2 kB"
+      "loro": "6.4 kB"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (parseTime)": {
-      "yjs": "62 ms",
-      "ywasm": "41 ms",
-      "automerge-wasm": "55 ms",
-      "automerge": "64 ms",
-      "loro": "40 ms"
+      "yjs": "43 ms",
+      "ywasm": "27 ms",
+      "automerge-wasm": "51 ms",
+      "automerge": "47 ms",
+      "loro": "25 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (time)": {
-      "yjs": "72 ms",
-      "ywasm": "405 ms",
-      "automerge-wasm": "677 ms",
-      "automerge": "311 ms",
-      "loro": "82 ms"
+      "yjs": "65 ms",
+      "ywasm": "365 ms",
+      "automerge-wasm": "458 ms",
+      "automerge": "287 ms",
+      "loro": "83 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (updateSize)": {
       "yjs": "33444 bytes",
@@ -542,37 +542,37 @@
     "[B2.2] Concurrently insert N characters at random positions (encodeTime)": {
       "yjs": "2 ms",
       "ywasm": "1 ms",
-      "automerge-wasm": "17 ms",
-      "automerge": "10 ms",
-      "loro": "83 ms"
+      "automerge-wasm": "15 ms",
+      "automerge": "9 ms",
+      "loro": "82 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (docSize)": {
-      "yjs": "66860 bytes",
-      "ywasm": "66852 bytes",
-      "automerge-wasm": "50705 bytes",
+      "yjs": "66852 bytes",
+      "ywasm": "66860 bytes",
+      "automerge-wasm": "50702 bytes",
       "automerge": "50683 bytes",
       "loro": "71858 bytes"
     },
     "[B2.2] Concurrently insert N characters at random positions (memUsed)": {
       "yjs": "2.4 MB",
-      "ywasm": "480 B",
+      "ywasm": "392 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "0 B"
+      "loro": "1.8 kB"
     },
     "[B2.2] Concurrently insert N characters at random positions (parseTime)": {
-      "yjs": "65 ms",
-      "ywasm": "52 ms",
-      "automerge-wasm": "151 ms",
-      "automerge": "67 ms",
-      "loro": "43 ms"
+      "yjs": "101 ms",
+      "ywasm": "34 ms",
+      "automerge-wasm": "122 ms",
+      "automerge": "53 ms",
+      "loro": "30 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (time)": {
-      "yjs": "86 ms",
-      "ywasm": "1046 ms",
-      "automerge-wasm": "1050 ms",
-      "automerge": "701 ms",
-      "loro": "111 ms"
+      "yjs": "85 ms",
+      "ywasm": "1014 ms",
+      "automerge-wasm": "784 ms",
+      "automerge": "663 ms",
+      "loro": "112 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (updateSize)": {
       "yjs": "88994 bytes",
@@ -584,37 +584,37 @@
     "[B2.3] Concurrently insert N words at random positions (encodeTime)": {
       "yjs": "4 ms",
       "ywasm": "4 ms",
-      "automerge-wasm": "59 ms",
-      "automerge": "37 ms",
+      "automerge-wasm": "54 ms",
+      "automerge": "38 ms",
       "loro": "145 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (docSize)": {
       "yjs": "178137 bytes",
-      "ywasm": "178137 bytes",
-      "automerge-wasm": "191497 bytes",
+      "ywasm": "178130 bytes",
+      "automerge-wasm": "191496 bytes",
       "automerge": "185019 bytes",
-      "loro": "188456 bytes"
+      "loro": "188458 bytes"
     },
     "[B2.3] Concurrently insert N words at random positions (memUsed)": {
-      "yjs": "5.6 MB",
-      "ywasm": "432 B",
-      "automerge-wasm": "18.4 kB",
+      "yjs": "5.5 MB",
+      "ywasm": "0 B",
+      "automerge-wasm": "688 B",
       "automerge": "0 B",
       "loro": "1.5 kB"
     },
     "[B2.3] Concurrently insert N words at random positions (parseTime)": {
-      "yjs": "76 ms",
-      "ywasm": "73 ms",
-      "automerge-wasm": "317 ms",
-      "automerge": "190 ms",
-      "loro": "66 ms"
+      "yjs": "85 ms",
+      "ywasm": "71 ms",
+      "automerge-wasm": "266 ms",
+      "automerge": "168 ms",
+      "loro": "52 ms"
     },
     "[B2.4] Concurrently insert & delete (time)": {
-      "yjs": "232 ms",
-      "ywasm": "2740 ms",
-      "automerge-wasm": "2564 ms",
-      "automerge": "1113 ms",
-      "loro": "204 ms"
+      "yjs": "178 ms",
+      "ywasm": "2786 ms",
+      "automerge-wasm": "1784 ms",
+      "automerge": "1066 ms",
+      "loro": "208 ms"
     },
     "[B2.4] Concurrently insert & delete (updateSize)": {
       "yjs": "139517 bytes",
@@ -624,169 +624,169 @@
       "loro": "163564 bytes"
     },
     "[B2.4] Concurrently insert & delete (encodeTime)": {
-      "yjs": "21 ms",
-      "ywasm": "7 ms",
+      "yjs": "12 ms",
+      "ywasm": "6 ms",
       "automerge-wasm": "76 ms",
       "automerge": "62 ms",
-      "loro": "245 ms"
+      "loro": "233 ms"
     },
     "[B2.4] Concurrently insert & delete (docSize)": {
       "yjs": "279172 bytes",
-      "ywasm": "279172 bytes",
-      "automerge-wasm": "307291 bytes",
-      "automerge": "293829 bytes",
-      "loro": "289595 bytes"
+      "ywasm": "279166 bytes",
+      "automerge-wasm": "307289 bytes",
+      "automerge": "293828 bytes",
+      "loro": "289590 bytes"
     },
     "[B2.4] Concurrently insert & delete (memUsed)": {
-      "yjs": "9.4 MB",
-      "ywasm": "432 B",
+      "yjs": "8.2 MB",
+      "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "1.7 kB"
+      "loro": "1.8 kB"
     },
     "[B2.4] Concurrently insert & delete (parseTime)": {
-      "yjs": "142 ms",
-      "ywasm": "84 ms",
-      "automerge-wasm": "434 ms",
-      "automerge": "278 ms",
-      "loro": "70 ms"
+      "yjs": "121 ms",
+      "ywasm": "78 ms",
+      "automerge-wasm": "410 ms",
+      "automerge": "255 ms",
+      "loro": "50 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (time)": {
-      "yjs": "91 ms",
-      "ywasm": "276 ms",
-      "automerge-wasm": "34 ms",
-      "automerge": "1616 ms",
-      "loro": "58 ms"
+      "yjs": "75 ms",
+      "ywasm": "290 ms",
+      "automerge-wasm": "43 ms",
+      "automerge": "1632 ms",
+      "loro": "56 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (updateSize)": {
-      "yjs": "49181 bytes",
+      "yjs": "49169 bytes",
       "ywasm": "49169 bytes",
       "automerge-wasm": "283296 bytes",
       "automerge": "283296 bytes",
       "loro": "161636 bytes"
     },
     "[B3.1] 20√N clients concurrently set number in Map (encodeTime)": {
-      "yjs": "4 ms",
-      "ywasm": "2 ms",
-      "automerge-wasm": "20 ms",
-      "automerge": "12 ms",
+      "yjs": "2 ms",
+      "ywasm": "1 ms",
+      "automerge-wasm": "17 ms",
+      "automerge": "11 ms",
       "loro": "2 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (docSize)": {
-      "yjs": "32246 bytes",
-      "ywasm": "32213 bytes",
-      "automerge-wasm": "86168 bytes",
-      "automerge": "86170 bytes",
+      "yjs": "32225 bytes",
+      "ywasm": "32209 bytes",
+      "automerge-wasm": "86044 bytes",
+      "automerge": "86167 bytes",
       "loro": "21506 bytes"
     },
     "[B3.1] 20√N clients concurrently set number in Map (memUsed)": {
-      "yjs": "196.3 kB",
-      "ywasm": "272 B",
-      "automerge-wasm": "480 B",
-      "automerge": "0 B",
-      "loro": "608 B"
+      "yjs": "0 B",
+      "ywasm": "176 B",
+      "automerge-wasm": "368 B",
+      "automerge": "344 B",
+      "loro": "824 B"
     },
     "[B3.1] 20√N clients concurrently set number in Map (parseTime)": {
-      "yjs": "100 ms",
-      "ywasm": "77 ms",
-      "automerge-wasm": "77 ms",
-      "automerge": "48 ms",
-      "loro": "71 ms"
+      "yjs": "104 ms",
+      "ywasm": "70 ms",
+      "automerge-wasm": "50 ms",
+      "automerge": "37 ms",
+      "loro": "40 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (time)": {
       "yjs": "84 ms",
-      "ywasm": "284 ms",
-      "automerge-wasm": "45 ms",
-      "automerge": "1727 ms",
-      "loro": "72 ms"
+      "ywasm": "278 ms",
+      "automerge-wasm": "47 ms",
+      "automerge": "1726 ms",
+      "loro": "67 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (updateSize)": {
       "yjs": "85082 bytes",
-      "ywasm": "85069 bytes",
+      "ywasm": "85085 bytes",
       "automerge-wasm": "325370 bytes",
       "automerge": "398090 bytes",
       "loro": "200630 bytes"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (encodeTime)": {
-      "yjs": "4 ms",
+      "yjs": "3 ms",
       "ywasm": "2 ms",
-      "automerge-wasm": "23 ms",
-      "automerge": "32 ms",
-      "loro": "3 ms"
+      "automerge-wasm": "22 ms",
+      "automerge": "30 ms",
+      "loro": "2 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (docSize)": {
-      "yjs": "32241 bytes",
-      "ywasm": "32218 bytes",
-      "automerge-wasm": "93420 bytes",
-      "automerge": "112588 bytes",
-      "loro": "41858 bytes"
+      "yjs": "32235 bytes",
+      "ywasm": "32249 bytes",
+      "automerge-wasm": "93398 bytes",
+      "automerge": "112570 bytes",
+      "loro": "40494 bytes"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (memUsed)": {
-      "yjs": "232.4 kB",
+      "yjs": "0 B",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "0 B"
+      "loro": "136 B"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (parseTime)": {
-      "yjs": "93 ms",
-      "ywasm": "75 ms",
-      "automerge-wasm": "100 ms",
-      "automerge": "93 ms",
-      "loro": "84 ms"
+      "yjs": "102 ms",
+      "ywasm": "70 ms",
+      "automerge-wasm": "54 ms",
+      "automerge": "86 ms",
+      "loro": "45 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (time)": {
-      "yjs": "88 ms",
+      "yjs": "86 ms",
       "ywasm": "299 ms",
-      "automerge-wasm": "232 ms",
-      "automerge": "2644 ms",
+      "automerge-wasm": "178 ms",
+      "automerge": "2335 ms",
       "loro": "116 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (updateSize)": {
-      "yjs": "7826225 bytes",
-      "ywasm": "7826232 bytes",
+      "yjs": "7826222 bytes",
+      "ywasm": "7826231 bytes",
       "automerge-wasm": "8063440 bytes",
       "automerge": "8063440 bytes",
       "loro": "7940240 bytes"
     },
     "[B3.3] 20√N clients concurrently set String in Map (encodeTime)": {
-      "yjs": "4 ms",
+      "yjs": "2 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "96 ms",
-      "automerge": "105 ms",
-      "loro": "51 ms"
+      "automerge": "91 ms",
+      "loro": "46 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (docSize)": {
-      "yjs": "38370 bytes",
-      "ywasm": "35296 bytes",
-      "automerge-wasm": "97995 bytes",
-      "automerge": "98003 bytes",
-      "loro": "7799994 bytes"
+      "yjs": "38357 bytes",
+      "ywasm": "38376 bytes",
+      "automerge-wasm": "98010 bytes",
+      "automerge": "98047 bytes",
+      "loro": "7798572 bytes"
     },
     "[B3.3] 20√N clients concurrently set String in Map (memUsed)": {
-      "yjs": "179.2 kB",
-      "ywasm": "200 B",
+      "yjs": "243 kB",
+      "ywasm": "0 B",
       "automerge-wasm": "0 B",
       "automerge": "0 B",
-      "loro": "704 B"
+      "loro": "696 B"
     },
     "[B3.3] 20√N clients concurrently set String in Map (parseTime)": {
-      "yjs": "104 ms",
-      "ywasm": "86 ms",
-      "automerge-wasm": "123 ms",
-      "automerge": "130 ms",
-      "loro": "70 ms"
+      "yjs": "97 ms",
+      "ywasm": "52 ms",
+      "automerge-wasm": "110 ms",
+      "automerge": "118 ms",
+      "loro": "55 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (time)": {
-      "yjs": "75 ms",
+      "yjs": "72 ms",
       "ywasm": "283 ms",
-      "automerge-wasm": "30 ms",
-      "automerge": "2726 ms",
-      "loro": "233 ms"
+      "automerge-wasm": "29 ms",
+      "automerge": "2780 ms",
+      "loro": "227 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (updateSize)": {
-      "yjs": "52743 bytes",
-      "ywasm": "52740 bytes",
+      "yjs": "52738 bytes",
+      "ywasm": "52751 bytes",
       "automerge-wasm": "285330 bytes",
       "automerge": "311830 bytes",
       "loro": "166750 bytes"
@@ -795,88 +795,88 @@
       "yjs": "2 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "11 ms",
-      "automerge": "18 ms",
+      "automerge": "17 ms",
       "loro": "8 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (docSize)": {
-      "yjs": "26588 bytes",
-      "ywasm": "26585 bytes",
-      "automerge-wasm": "86507 bytes",
-      "automerge": "96446 bytes",
-      "loro": "31093 bytes"
+      "yjs": "26583 bytes",
+      "ywasm": "26596 bytes",
+      "automerge-wasm": "86529 bytes",
+      "automerge": "96463 bytes",
+      "loro": "31119 bytes"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (memUsed)": {
-      "yjs": "720.9 kB",
-      "ywasm": "5.5 kB",
-      "automerge-wasm": "248 B",
-      "automerge": "38.2 kB",
-      "loro": "472 B"
+      "yjs": "588.8 kB",
+      "ywasm": "0 B",
+      "automerge-wasm": "0 B",
+      "automerge": "0 B",
+      "loro": "480 B"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (parseTime)": {
-      "yjs": "76 ms",
-      "ywasm": "76 ms",
-      "automerge-wasm": "57 ms",
-      "automerge": "59 ms",
-      "loro": "38 ms"
+      "yjs": "84 ms",
+      "ywasm": "60 ms",
+      "automerge-wasm": "44 ms",
+      "automerge": "42 ms",
+      "loro": "29 ms"
     },
     "[B4] Apply real-world editing dataset (time)": {
-      "yjs": "1803 ms",
-      "ywasm": "43943 ms",
-      "automerge-wasm": "725 ms",
-      "automerge": "12746 ms",
-      "loro": "2960 ms"
+      "yjs": "5714 ms",
+      "ywasm": "28675 ms",
+      "automerge-wasm": "3859 ms",
+      "automerge": "14326 ms",
+      "loro": "3089 ms"
     },
     "[B4] Apply real-world editing dataset (encodeTime)": {
-      "yjs": "12 ms",
-      "ywasm": "4 ms",
-      "automerge-wasm": "110 ms",
-      "automerge": "219 ms",
-      "loro": "75 ms"
+      "yjs": "11 ms",
+      "ywasm": "3 ms",
+      "automerge-wasm": "190 ms",
+      "automerge": "185 ms",
+      "loro": "77 ms"
     },
     "[B4] Apply real-world editing dataset (docSize)": {
       "yjs": "159929 bytes",
       "ywasm": "159929 bytes",
-      "automerge-wasm": "129095 bytes",
+      "automerge-wasm": "129116 bytes",
       "automerge": "129116 bytes",
       "loro": "258228 bytes"
     },
     "[B4] Apply real-world editing dataset (parseTime)": {
-      "yjs": "38 ms",
-      "ywasm": "17 ms",
-      "automerge-wasm": "403 ms",
-      "automerge": "2115 ms",
+      "yjs": "39 ms",
+      "ywasm": "16 ms",
+      "automerge-wasm": "1793 ms",
+      "automerge": "1805 ms",
       "loro": "13 ms"
     },
     "[B4] Apply real-world editing dataset (memUsed)": {
-      "yjs": "3.5 MB",
-      "ywasm": "856 B",
+      "yjs": "3.2 MB",
+      "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "139.6 kB",
+      "automerge": "0 B",
       "loro": "0 B"
     },
     "[B4x100] Apply real-world editing dataset 100 times (time)": {
-      "yjs": "199319 ms",
-      "ywasm": "2732719 ms",
-      "loro": "300508 ms"
+      "yjs": "608908 ms",
+      "ywasm": "2829633 ms",
+      "loro": "309689 ms"
     },
     "[B4x100] Apply real-world editing dataset 100 times (encodeTime)": {
-      "yjs": "388 ms",
-      "ywasm": "209 ms",
-      "loro": "14360 ms"
+      "yjs": "365 ms",
+      "ywasm": "186 ms",
+      "loro": "14429 ms"
     },
     "[B4x100] Apply real-world editing dataset 100 times (docSize)": {
-      "yjs": "15989245 bytes",
+      "yjs": "15989244 bytes",
       "ywasm": "15989245 bytes",
       "loro": "25805795 bytes"
     },
     "[B4x100] Apply real-world editing dataset 100 times (parseTime)": {
-      "yjs": "2183 ms",
-      "ywasm": "1564 ms",
-      "loro": "1317 ms"
+      "yjs": "2622 ms",
+      "ywasm": "1328 ms",
+      "loro": "1304 ms"
     },
     "[B4x100] Apply real-world editing dataset 100 times (memUsed)": {
-      "yjs": "352.9 MB",
-      "ywasm": "0 B",
+      "yjs": "327.1 MB",
+      "ywasm": "24 B",
       "loro": "2.1 kB"
     }
   }

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -4,733 +4,855 @@
       "yjs": "13.6.11",
       "ywasm": "0.9.3",
       "automerge-wasm": "0.9.0",
-      "automerge": "2.1.10"
+      "automerge": "2.1.10",
+      "loro": "0.10.0"
     },
     "Bundle size": {
       "yjs": "80413 bytes",
       "ywasm": "677652 bytes",
       "automerge-wasm": "1695301 bytes",
-      "automerge": "1737571 bytes"
+      "automerge": "1737571 bytes",
+      "loro": "1059834 bytes"
     },
     "Bundle size (gzipped)": {
       "yjs": "23571 bytes",
       "ywasm": "213832 bytes",
       "automerge-wasm": "592235 bytes",
-      "automerge": "604118 bytes"
+      "automerge": "604118 bytes",
+      "loro": "401549 bytes"
     },
     "[B1.1] Append N characters (time)": {
       "yjs": "164 ms",
       "ywasm": "135 ms",
       "automerge-wasm": "117 ms",
-      "automerge": "364 ms"
+      "automerge": "364 ms",
+      "loro": "126 ms"
     },
     "[B1.1] Append N characters (avgUpdateSize)": {
       "yjs": "27 bytes",
       "ywasm": "27 bytes",
       "automerge-wasm": "121 bytes",
-      "automerge": "121 bytes"
+      "automerge": "121 bytes",
+      "loro": "109 bytes"
     },
     "[B1.1] Append N characters (encodeTime)": {
       "yjs": "1 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "7 ms",
-      "automerge": "7 ms"
+      "automerge": "7 ms",
+      "loro": "0 ms"
     },
     "[B1.1] Append N characters (docSize)": {
       "yjs": "6031 bytes",
       "ywasm": "6031 bytes",
       "automerge-wasm": "3992 bytes",
-      "automerge": "3992 bytes"
+      "automerge": "3992 bytes",
+      "loro": "6152 bytes"
     },
     "[B1.1] Append N characters (memUsed)": {
       "yjs": "0 B",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "0 B"
     },
     "[B1.1] Append N characters (parseTime)": {
       "yjs": "46 ms",
       "ywasm": "43 ms",
       "automerge-wasm": "91 ms",
-      "automerge": "95 ms"
+      "automerge": "95 ms",
+      "loro": "38 ms"
     },
     "[B1.2] Insert string of length N (time)": {
       "yjs": "1 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "8 ms",
-      "automerge": "9 ms"
+      "automerge": "9 ms",
+      "loro": "0 ms"
     },
     "[B1.2] Insert string of length N (avgUpdateSize)": {
       "yjs": "6031 bytes",
       "ywasm": "6031 bytes",
       "automerge-wasm": "6201 bytes",
-      "automerge": "6201 bytes"
+      "automerge": "6201 bytes",
+      "loro": "6107 bytes"
     },
     "[B1.2] Insert string of length N (encodeTime)": {
       "yjs": "1 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "3 ms",
-      "automerge": "3 ms"
+      "automerge": "3 ms",
+      "loro": "0 ms"
     },
     "[B1.2] Insert string of length N (docSize)": {
       "yjs": "6031 bytes",
       "ywasm": "6031 bytes",
       "automerge-wasm": "3974 bytes",
-      "automerge": "3974 bytes"
+      "automerge": "3974 bytes",
+      "loro": "6107 bytes"
     },
     "[B1.2] Insert string of length N (memUsed)": {
       "yjs": "192.4 kB",
       "ywasm": "424.3 kB",
       "automerge-wasm": "840 B",
-      "automerge": "9.2 kB"
+      "automerge": "9.2 kB",
+      "loro": "132 kB"
     },
     "[B1.2] Insert string of length N (parseTime)": {
       "yjs": "56 ms",
       "ywasm": "44 ms",
       "automerge-wasm": "53 ms",
-      "automerge": "43 ms"
+      "automerge": "43 ms",
+      "loro": "43 ms"
     },
     "[B1.3] Prepend N characters (time)": {
       "yjs": "132 ms",
       "ywasm": "21 ms",
       "automerge-wasm": "86 ms",
-      "automerge": "314 ms"
+      "automerge": "314 ms",
+      "loro": "85 ms"
     },
     "[B1.3] Prepend N characters (avgUpdateSize)": {
       "yjs": "27 bytes",
       "ywasm": "27 bytes",
       "automerge-wasm": "116 bytes",
-      "automerge": "116 bytes"
+      "automerge": "116 bytes",
+      "loro": "108 bytes"
     },
     "[B1.3] Prepend N characters (encodeTime)": {
       "yjs": "3 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "5 ms",
-      "automerge": "5 ms"
+      "automerge": "5 ms",
+      "loro": "2 ms"
     },
     "[B1.3] Prepend N characters (docSize)": {
       "yjs": "6041 bytes",
       "ywasm": "6041 bytes",
       "automerge-wasm": "3988 bytes",
-      "automerge": "3988 bytes"
+      "automerge": "3988 bytes",
+      "loro": "12114 bytes"
     },
     "[B1.3] Prepend N characters (memUsed)": {
       "yjs": "1.2 MB",
       "ywasm": "8.3 kB",
       "automerge-wasm": "7.9 kB",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "0 B"
     },
     "[B1.3] Prepend N characters (parseTime)": {
       "yjs": "85 ms",
       "ywasm": "50 ms",
       "automerge-wasm": "90 ms",
-      "automerge": "96 ms"
+      "automerge": "96 ms",
+      "loro": "69 ms"
     },
     "[B1.4] Insert N characters at random positions (time)": {
       "yjs": "145 ms",
       "ywasm": "130 ms",
       "automerge-wasm": "105 ms",
-      "automerge": "314 ms"
+      "automerge": "314 ms",
+      "loro": "84 ms"
     },
     "[B1.4] Insert N characters at random positions (avgUpdateSize)": {
       "yjs": "29 bytes",
       "ywasm": "29 bytes",
       "automerge-wasm": "121 bytes",
-      "automerge": "121 bytes"
+      "automerge": "121 bytes",
+      "loro": "109 bytes"
     },
     "[B1.4] Insert N characters at random positions (encodeTime)": {
       "yjs": "7 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "8 ms",
-      "automerge": "9 ms"
+      "automerge": "9 ms",
+      "loro": "2 ms"
     },
     "[B1.4] Insert N characters at random positions (docSize)": {
       "yjs": "29554 bytes",
       "ywasm": "29554 bytes",
       "automerge-wasm": "24743 bytes",
-      "automerge": "24743 bytes"
+      "automerge": "24743 bytes",
+      "loro": "23527 bytes"
     },
     "[B1.4] Insert N characters at random positions (memUsed)": {
       "yjs": "1.1 MB",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "9.5 kB"
+      "automerge": "9.5 kB",
+      "loro": "0 B"
     },
     "[B1.4] Insert N characters at random positions (parseTime)": {
       "yjs": "90 ms",
       "ywasm": "43 ms",
       "automerge-wasm": "105 ms",
-      "automerge": "106 ms"
+      "automerge": "106 ms",
+      "loro": "63 ms"
     },
     "[B1.5] Insert N words at random positions (time)": {
       "yjs": "166 ms",
       "ywasm": "438 ms",
       "automerge-wasm": "326 ms",
-      "automerge": "515 ms"
+      "automerge": "515 ms",
+      "loro": "87 ms"
     },
     "[B1.5] Insert N words at random positions (avgUpdateSize)": {
       "yjs": "36 bytes",
       "ywasm": "36 bytes",
       "automerge-wasm": "131 bytes",
-      "automerge": "131 bytes"
+      "automerge": "131 bytes",
+      "loro": "117 bytes"
     },
     "[B1.5] Insert N words at random positions (encodeTime)": {
       "yjs": "10 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "21 ms",
-      "automerge": "23 ms"
+      "automerge": "23 ms",
+      "loro": "2 ms"
     },
     "[B1.5] Insert N words at random positions (docSize)": {
       "yjs": "87924 bytes",
       "ywasm": "87924 bytes",
       "automerge-wasm": "96203 bytes",
-      "automerge": "96203 bytes"
+      "automerge": "96203 bytes",
+      "loro": "62296 bytes"
     },
     "[B1.5] Insert N words at random positions (memUsed)": {
       "yjs": "2.3 MB",
       "ywasm": "720 B",
       "automerge-wasm": "0 B",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "0 B"
     },
     "[B1.5] Insert N words at random positions (parseTime)": {
       "yjs": "74 ms",
       "ywasm": "48 ms",
       "automerge-wasm": "147 ms",
-      "automerge": "171 ms"
+      "automerge": "171 ms",
+      "loro": "79 ms"
     },
     "[B1.6] Insert string, then delete it (time)": {
       "yjs": "2 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "24 ms",
-      "automerge": "24 ms"
+      "automerge": "24 ms",
+      "loro": "2 ms"
     },
     "[B1.6] Insert string, then delete it (avgUpdateSize)": {
       "yjs": "6053 bytes",
       "ywasm": "6053 bytes",
       "automerge-wasm": "6338 bytes",
-      "automerge": "6338 bytes"
+      "automerge": "6338 bytes",
+      "loro": "6217 bytes"
     },
     "[B1.6] Insert string, then delete it (encodeTime)": {
       "yjs": "0 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "4 ms",
-      "automerge": "4 ms"
+      "automerge": "4 ms",
+      "loro": "0 ms"
     },
     "[B1.6] Insert string, then delete it (docSize)": {
       "yjs": "38 bytes",
       "ywasm": "38 bytes",
       "automerge-wasm": "3993 bytes",
-      "automerge": "3993 bytes"
+      "automerge": "3993 bytes",
+      "loro": "6114 bytes"
     },
     "[B1.6] Insert string, then delete it (memUsed)": {
       "yjs": "65.7 kB",
       "ywasm": "0 B",
       "automerge-wasm": "584 B",
-      "automerge": "2.2 kB"
+      "automerge": "2.2 kB",
+      "loro": "2.6 kB"
     },
     "[B1.6] Insert string, then delete it (parseTime)": {
       "yjs": "59 ms",
       "ywasm": "43 ms",
       "automerge-wasm": "54 ms",
-      "automerge": "67 ms"
+      "automerge": "67 ms",
+      "loro": "38 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (time)": {
       "yjs": "171 ms",
       "ywasm": "137 ms",
       "automerge-wasm": "247 ms",
-      "automerge": "462 ms"
+      "automerge": "462 ms",
+      "loro": "107 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (avgUpdateSize)": {
       "yjs": "31 bytes",
       "ywasm": "31 bytes",
       "automerge-wasm": "135 bytes",
-      "automerge": "135 bytes"
+      "automerge": "135 bytes",
+      "loro": "113 bytes"
     },
     "[B1.7] Insert/Delete strings at random positions (encodeTime)": {
       "yjs": "8 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "20 ms",
-      "automerge": "21 ms"
+      "automerge": "21 ms",
+      "loro": "2 ms"
     },
     "[B1.7] Insert/Delete strings at random positions (docSize)": {
       "yjs": "28377 bytes",
       "ywasm": "28377 bytes",
       "automerge-wasm": "59281 bytes",
-      "automerge": "59281 bytes"
+      "automerge": "59281 bytes",
+      "loro": "47181 bytes"
     },
     "[B1.7] Insert/Delete strings at random positions (memUsed)": {
       "yjs": "1.2 MB",
       "ywasm": "480 B",
       "automerge-wasm": "0 B",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "0 B"
     },
     "[B1.7] Insert/Delete strings at random positions (parseTime)": {
       "yjs": "93 ms",
       "ywasm": "46 ms",
       "automerge-wasm": "131 ms",
-      "automerge": "136 ms"
+      "automerge": "136 ms",
+      "loro": "74 ms"
     },
     "[B1.8] Append N numbers (time)": {
       "yjs": "160 ms",
       "ywasm": "26 ms",
       "automerge-wasm": "120 ms",
-      "automerge": "455 ms"
+      "automerge": "455 ms",
+      "loro": "89 ms"
     },
     "[B1.8] Append N numbers (avgUpdateSize)": {
       "yjs": "32 bytes",
       "ywasm": "32 bytes",
       "automerge-wasm": "125 bytes",
-      "automerge": "125 bytes"
+      "automerge": "125 bytes",
+      "loro": "114 bytes"
     },
     "[B1.8] Append N numbers (encodeTime)": {
       "yjs": "4 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "9 ms",
-      "automerge": "10 ms"
+      "automerge": "10 ms",
+      "loro": "1 ms"
     },
     "[B1.8] Append N numbers (docSize)": {
       "yjs": "35634 bytes",
       "ywasm": "35634 bytes",
       "automerge-wasm": "26985 bytes",
-      "automerge": "26985 bytes"
+      "automerge": "26985 bytes",
+      "loro": "35712 bytes"
     },
     "[B1.8] Append N numbers (memUsed)": {
       "yjs": "0 B",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "63.8 kB"
+      "automerge": "63.8 kB",
+      "loro": "0 B"
     },
     "[B1.8] Append N numbers (parseTime)": {
       "yjs": "66 ms",
       "ywasm": "43 ms",
       "automerge-wasm": "97 ms",
-      "automerge": "101 ms"
+      "automerge": "101 ms",
+      "loro": "38 ms"
     },
     "[B1.9] Insert Array of N numbers (time)": {
       "yjs": "5 ms",
       "ywasm": "3 ms",
       "automerge-wasm": "8 ms",
-      "automerge": "40 ms"
+      "automerge": "40 ms",
+      "loro": "7 ms"
     },
     "[B1.9] Insert Array of N numbers (avgUpdateSize)": {
       "yjs": "35657 bytes",
       "ywasm": "35657 bytes",
       "automerge-wasm": "31199 bytes",
-      "automerge": "31199 bytes"
+      "automerge": "31199 bytes",
+      "loro": "35735 bytes"
     },
     "[B1.9] Insert Array of N numbers (encodeTime)": {
       "yjs": "1 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "4 ms",
-      "automerge": "5 ms"
+      "automerge": "5 ms",
+      "loro": "1 ms"
     },
     "[B1.9] Insert Array of N numbers (docSize)": {
       "yjs": "35657 bytes",
       "ywasm": "35657 bytes",
       "automerge-wasm": "26953 bytes",
-      "automerge": "26953 bytes"
+      "automerge": "26953 bytes",
+      "loro": "35735 bytes"
     },
     "[B1.9] Insert Array of N numbers (memUsed)": {
       "yjs": "45.6 kB",
       "ywasm": "552 B",
       "automerge-wasm": "344 B",
-      "automerge": "37.9 kB"
+      "automerge": "37.9 kB",
+      "loro": "2.5 kB"
     },
     "[B1.9] Insert Array of N numbers (parseTime)": {
       "yjs": "58 ms",
       "ywasm": "42 ms",
       "automerge-wasm": "57 ms",
-      "automerge": "68 ms"
+      "automerge": "68 ms",
+      "loro": "40 ms"
     },
     "[B1.10] Prepend N numbers (time)": {
       "yjs": "129 ms",
       "ywasm": "27 ms",
       "automerge-wasm": "214 ms",
-      "automerge": "530 ms"
+      "automerge": "530 ms",
+      "loro": "87 ms"
     },
     "[B1.10] Prepend N numbers (avgUpdateSize)": {
       "yjs": "32 bytes",
       "ywasm": "36 bytes",
       "automerge-wasm": "120 bytes",
-      "automerge": "120 bytes"
+      "automerge": "120 bytes",
+      "loro": "113 bytes"
     },
     "[B1.10] Prepend N numbers (encodeTime)": {
       "yjs": "6 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "9 ms",
-      "automerge": "8 ms"
+      "automerge": "8 ms",
+      "loro": "2 ms"
     },
     "[B1.10] Prepend N numbers (docSize)": {
       "yjs": "35665 bytes",
       "ywasm": "65658 bytes",
       "automerge-wasm": "26987 bytes",
-      "automerge": "26987 bytes"
+      "automerge": "26987 bytes",
+      "loro": "41740 bytes"
     },
     "[B1.10] Prepend N numbers (memUsed)": {
       "yjs": "1.9 MB",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "65.7 kB"
+      "automerge": "65.7 kB",
+      "loro": "0 B"
     },
     "[B1.10] Prepend N numbers (parseTime)": {
       "yjs": "73 ms",
       "ywasm": "45 ms",
       "automerge-wasm": "98 ms",
-      "automerge": "106 ms"
+      "automerge": "106 ms",
+      "loro": "59 ms"
     },
     "[B1.11] Insert N numbers at random positions (time)": {
       "yjs": "144 ms",
       "ywasm": "149 ms",
       "automerge-wasm": "130 ms",
-      "automerge": "470 ms"
+      "automerge": "470 ms",
+      "loro": "78 ms"
     },
     "[B1.11] Insert N numbers at random positions (avgUpdateSize)": {
       "yjs": "34 bytes",
       "ywasm": "34 bytes",
       "automerge-wasm": "125 bytes",
-      "automerge": "125 bytes"
+      "automerge": "125 bytes",
+      "loro": "114 bytes"
     },
     "[B1.11] Insert N numbers at random positions (encodeTime)": {
       "yjs": "8 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "9 ms",
-      "automerge": "11 ms"
+      "automerge": "11 ms",
+      "loro": "6 ms"
     },
     "[B1.11] Insert N numbers at random positions (docSize)": {
       "yjs": "59137 bytes",
       "ywasm": "59152 bytes",
       "automerge-wasm": "47746 bytes",
-      "automerge": "47746 bytes"
+      "automerge": "47746 bytes",
+      "loro": "53145 bytes"
     },
     "[B1.11] Insert N numbers at random positions (memUsed)": {
       "yjs": "2.1 MB",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "60.1 kB"
+      "automerge": "60.1 kB",
+      "loro": "0 B"
     },
     "[B1.11] Insert N numbers at random positions (parseTime)": {
       "yjs": "93 ms",
       "ywasm": "51 ms",
       "automerge-wasm": "127 ms",
-      "automerge": "104 ms"
+      "automerge": "104 ms",
+      "loro": "74 ms"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (time)": {
       "yjs": "3 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "51 ms",
-      "automerge": "71 ms"
+      "automerge": "71 ms",
+      "loro": "1 ms"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (updateSize)": {
       "yjs": "6093 bytes",
       "ywasm": "6094 bytes",
       "automerge-wasm": "9499 bytes",
-      "automerge": "9499 bytes"
+      "automerge": "9499 bytes",
+      "loro": "6218 bytes"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (encodeTime)": {
       "yjs": "0 ms",
       "ywasm": "0 ms",
       "automerge-wasm": "6 ms",
-      "automerge": "6 ms"
+      "automerge": "6 ms",
+      "loro": "0 ms"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (docSize)": {
       "yjs": "12150 bytes",
       "ywasm": "12152 bytes",
       "automerge-wasm": "8011 bytes",
-      "automerge": "8011 bytes"
+      "automerge": "8011 bytes",
+      "loro": "12237 bytes"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (memUsed)": {
       "yjs": "76.2 kB",
       "ywasm": "304 B",
       "automerge-wasm": "864 B",
-      "automerge": "14.5 kB"
+      "automerge": "14.5 kB",
+      "loro": "1.8 kB"
     },
     "[B2.1] Concurrently insert string of length N at index 0 (parseTime)": {
       "yjs": "62 ms",
       "ywasm": "41 ms",
       "automerge-wasm": "55 ms",
-      "automerge": "64 ms"
+      "automerge": "64 ms",
+      "loro": "39 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (time)": {
       "yjs": "72 ms",
       "ywasm": "405 ms",
       "automerge-wasm": "677 ms",
-      "automerge": "311 ms"
+      "automerge": "311 ms",
+      "loro": "78 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (updateSize)": {
       "yjs": "33444 bytes",
       "ywasm": "177007 bytes",
       "automerge-wasm": "1093293 bytes",
-      "automerge": "27476 bytes"
+      "automerge": "27476 bytes",
+      "loro": "23735 bytes"
     },
     "[B2.2] Concurrently insert N characters at random positions (encodeTime)": {
       "yjs": "2 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "17 ms",
-      "automerge": "10 ms"
+      "automerge": "10 ms",
+      "loro": "3 ms"
     },
     "[B2.2] Concurrently insert N characters at random positions (docSize)": {
       "yjs": "66860 bytes",
       "ywasm": "66852 bytes",
       "automerge-wasm": "50705 bytes",
-      "automerge": "50683 bytes"
+      "automerge": "50683 bytes",
+      "loro": "47273 bytes"
     },
     "[B2.2] Concurrently insert N characters at random positions (memUsed)": {
       "yjs": "2.4 MB",
       "ywasm": "480 B",
       "automerge-wasm": "0 B",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "0 B"
     },
     "[B2.2] Concurrently insert N characters at random positions (parseTime)": {
       "yjs": "65 ms",
       "ywasm": "52 ms",
       "automerge-wasm": "151 ms",
-      "automerge": "67 ms"
+      "automerge": "67 ms",
+      "loro": "91 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (time)": {
       "yjs": "86 ms",
       "ywasm": "1046 ms",
       "automerge-wasm": "1050 ms",
-      "automerge": "701 ms"
+      "automerge": "701 ms",
+      "loro": "110 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (updateSize)": {
       "yjs": "88994 bytes",
       "ywasm": "215213 bytes",
       "automerge-wasm": "1185202 bytes",
-      "automerge": "122485 bytes"
+      "automerge": "122485 bytes",
+      "loro": "62098 bytes"
     },
     "[B2.3] Concurrently insert N words at random positions (encodeTime)": {
       "yjs": "4 ms",
       "ywasm": "4 ms",
       "automerge-wasm": "59 ms",
-      "automerge": "37 ms"
+      "automerge": "37 ms",
+      "loro": "3 ms"
     },
     "[B2.3] Concurrently insert N words at random positions (docSize)": {
       "yjs": "178137 bytes",
       "ywasm": "178137 bytes",
       "automerge-wasm": "191497 bytes",
-      "automerge": "185019 bytes"
+      "automerge": "185019 bytes",
+      "loro": "123997 bytes"
     },
     "[B2.3] Concurrently insert N words at random positions (memUsed)": {
       "yjs": "5.6 MB",
       "ywasm": "432 B",
       "automerge-wasm": "18.4 kB",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "0 B"
     },
     "[B2.3] Concurrently insert N words at random positions (parseTime)": {
       "yjs": "76 ms",
       "ywasm": "73 ms",
       "automerge-wasm": "317 ms",
-      "automerge": "190 ms"
+      "automerge": "190 ms",
+      "loro": "138 ms"
     },
     "[B2.4] Concurrently insert & delete (time)": {
       "yjs": "232 ms",
       "ywasm": "2740 ms",
       "automerge-wasm": "2564 ms",
-      "automerge": "1113 ms"
+      "automerge": "1113 ms",
+      "loro": "205 ms"
     },
     "[B2.4] Concurrently insert & delete (updateSize)": {
       "yjs": "139517 bytes",
       "ywasm": "398881 bytes",
       "automerge-wasm": "2395876 bytes",
-      "automerge": "298810 bytes"
+      "automerge": "298810 bytes",
+      "loro": "109161 bytes"
     },
     "[B2.4] Concurrently insert & delete (encodeTime)": {
       "yjs": "21 ms",
       "ywasm": "7 ms",
       "automerge-wasm": "76 ms",
-      "automerge": "62 ms"
+      "automerge": "62 ms",
+      "loro": "9 ms"
     },
     "[B2.4] Concurrently insert & delete (docSize)": {
       "yjs": "279172 bytes",
       "ywasm": "279172 bytes",
       "automerge-wasm": "307291 bytes",
-      "automerge": "293829 bytes"
+      "automerge": "293829 bytes",
+      "loro": "218118 bytes"
     },
     "[B2.4] Concurrently insert & delete (memUsed)": {
       "yjs": "9.4 MB",
       "ywasm": "432 B",
       "automerge-wasm": "0 B",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "0 B"
     },
     "[B2.4] Concurrently insert & delete (parseTime)": {
       "yjs": "142 ms",
       "ywasm": "84 ms",
       "automerge-wasm": "434 ms",
-      "automerge": "278 ms"
+      "automerge": "278 ms",
+      "loro": "204 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (time)": {
       "yjs": "91 ms",
       "ywasm": "276 ms",
       "automerge-wasm": "34 ms",
-      "automerge": "1616 ms"
+      "automerge": "1616 ms",
+      "loro": "1891 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (updateSize)": {
       "yjs": "49181 bytes",
       "ywasm": "49169 bytes",
       "automerge-wasm": "283296 bytes",
-      "automerge": "283296 bytes"
+      "automerge": "283296 bytes",
+      "loro": "161636 bytes"
     },
     "[B3.1] 20√N clients concurrently set number in Map (encodeTime)": {
       "yjs": "4 ms",
       "ywasm": "2 ms",
       "automerge-wasm": "20 ms",
-      "automerge": "12 ms"
+      "automerge": "12 ms",
+      "loro": "1 ms"
     },
     "[B3.1] 20√N clients concurrently set number in Map (docSize)": {
       "yjs": "32246 bytes",
       "ywasm": "32213 bytes",
       "automerge-wasm": "86168 bytes",
-      "automerge": "86170 bytes"
+      "automerge": "86170 bytes",
+      "loro": "21487 bytes"
     },
     "[B3.1] 20√N clients concurrently set number in Map (memUsed)": {
       "yjs": "196.3 kB",
       "ywasm": "272 B",
       "automerge-wasm": "480 B",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "144 B"
     },
     "[B3.1] 20√N clients concurrently set number in Map (parseTime)": {
       "yjs": "100 ms",
       "ywasm": "77 ms",
       "automerge-wasm": "77 ms",
-      "automerge": "48 ms"
+      "automerge": "48 ms",
+      "loro": "44 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (time)": {
       "yjs": "84 ms",
       "ywasm": "284 ms",
       "automerge-wasm": "45 ms",
-      "automerge": "1727 ms"
+      "automerge": "1727 ms",
+      "loro": "2030 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (updateSize)": {
       "yjs": "85082 bytes",
       "ywasm": "85069 bytes",
       "automerge-wasm": "325370 bytes",
-      "automerge": "398090 bytes"
+      "automerge": "398090 bytes",
+      "loro": "200630 bytes"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (encodeTime)": {
       "yjs": "4 ms",
       "ywasm": "2 ms",
       "automerge-wasm": "23 ms",
-      "automerge": "32 ms"
+      "automerge": "32 ms",
+      "loro": "3 ms"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (docSize)": {
       "yjs": "32241 bytes",
       "ywasm": "32218 bytes",
       "automerge-wasm": "93420 bytes",
-      "automerge": "112588 bytes"
+      "automerge": "112588 bytes",
+      "loro": "40475 bytes"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (memUsed)": {
       "yjs": "232.4 kB",
       "ywasm": "0 B",
       "automerge-wasm": "0 B",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "312 B"
     },
     "[B3.2] 20√N clients concurrently set Object in Map (parseTime)": {
       "yjs": "93 ms",
       "ywasm": "75 ms",
       "automerge-wasm": "100 ms",
-      "automerge": "93 ms"
+      "automerge": "93 ms",
+      "loro": "96 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (time)": {
       "yjs": "88 ms",
       "ywasm": "299 ms",
       "automerge-wasm": "232 ms",
-      "automerge": "2644 ms"
+      "automerge": "2644 ms",
+      "loro": "2037 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (updateSize)": {
       "yjs": "7826225 bytes",
       "ywasm": "7826232 bytes",
       "automerge-wasm": "8063440 bytes",
-      "automerge": "8063440 bytes"
+      "automerge": "8063440 bytes",
+      "loro": "7940240 bytes"
     },
     "[B3.3] 20√N clients concurrently set String in Map (encodeTime)": {
       "yjs": "4 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "96 ms",
-      "automerge": "105 ms"
+      "automerge": "105 ms",
+      "loro": "45 ms"
     },
     "[B3.3] 20√N clients concurrently set String in Map (docSize)": {
       "yjs": "38370 bytes",
       "ywasm": "35296 bytes",
       "automerge-wasm": "97995 bytes",
-      "automerge": "98003 bytes"
+      "automerge": "98003 bytes",
+      "loro": "7799167 bytes"
     },
     "[B3.3] 20√N clients concurrently set String in Map (memUsed)": {
       "yjs": "179.2 kB",
       "ywasm": "200 B",
       "automerge-wasm": "0 B",
-      "automerge": "0 B"
+      "automerge": "0 B",
+      "loro": "656 B"
     },
     "[B3.3] 20√N clients concurrently set String in Map (parseTime)": {
       "yjs": "104 ms",
       "ywasm": "86 ms",
       "automerge-wasm": "123 ms",
-      "automerge": "130 ms"
+      "automerge": "130 ms",
+      "loro": "74 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (time)": {
       "yjs": "75 ms",
       "ywasm": "283 ms",
       "automerge-wasm": "30 ms",
-      "automerge": "2726 ms"
+      "automerge": "2726 ms",
+      "loro": "107643 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (updateSize)": {
       "yjs": "52743 bytes",
       "ywasm": "52740 bytes",
       "automerge-wasm": "285330 bytes",
-      "automerge": "311830 bytes"
+      "automerge": "311830 bytes",
+      "loro": "166750 bytes"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (encodeTime)": {
       "yjs": "2 ms",
       "ywasm": "1 ms",
       "automerge-wasm": "11 ms",
-      "automerge": "18 ms"
+      "automerge": "18 ms",
+      "loro": "2 ms"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (docSize)": {
       "yjs": "26588 bytes",
       "ywasm": "26585 bytes",
       "automerge-wasm": "86507 bytes",
-      "automerge": "96446 bytes"
+      "automerge": "96446 bytes",
+      "loro": "28140 bytes"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (memUsed)": {
       "yjs": "720.9 kB",
       "ywasm": "5.5 kB",
       "automerge-wasm": "248 B",
-      "automerge": "38.2 kB"
+      "automerge": "38.2 kB",
+      "loro": "6.1 kB"
     },
     "[B3.4] 20√N clients concurrently insert text in Array (parseTime)": {
       "yjs": "76 ms",
       "ywasm": "76 ms",
       "automerge-wasm": "57 ms",
-      "automerge": "59 ms"
+      "automerge": "59 ms",
+      "loro": "254 ms"
     },
     "[B4] Apply real-world editing dataset (time)": {
       "yjs": "1803 ms",
       "ywasm": "43943 ms",
       "automerge-wasm": "725 ms",
-      "automerge": "12746 ms"
+      "automerge": "12746 ms",
+      "loro": "1198 ms"
     },
     "[B4] Apply real-world editing dataset (encodeTime)": {
       "yjs": "12 ms",
       "ywasm": "4 ms",
       "automerge-wasm": "110 ms",
-      "automerge": "219 ms"
+      "automerge": "219 ms",
+      "loro": "7 ms"
     },
     "[B4] Apply real-world editing dataset (docSize)": {
       "yjs": "159929 bytes",
       "ywasm": "159929 bytes",
       "automerge-wasm": "129095 bytes",
-      "automerge": "129116 bytes"
+      "automerge": "129116 bytes",
+      "loro": "229732 bytes"
     },
     "[B4] Apply real-world editing dataset (parseTime)": {
       "yjs": "38 ms",
       "ywasm": "17 ms",
       "automerge-wasm": "403 ms",
-      "automerge": "2115 ms"
+      "automerge": "2115 ms",
+      "loro": "74 ms"
     },
     "[B4] Apply real-world editing dataset (memUsed)": {
       "yjs": "3.5 MB",
       "ywasm": "856 B",
       "automerge-wasm": "0 B",
-      "automerge": "139.6 kB"
+      "automerge": "139.6 kB",
+      "loro": "0 B"
     },
     "[B4x100] Apply real-world editing dataset 100 times (time)": {
       "yjs": "199319 ms",

--- a/benchmarks/yjs/bundle.js
+++ b/benchmarks/yjs/bundle.js
@@ -1,1 +1,1 @@
-export * from 'yjs'
+export { Doc, applyUpdateV2, encodeStateAsUpdateV2 } from 'yjs'

--- a/benchmarks/yjs/factory.js
+++ b/benchmarks/yjs/factory.js
@@ -9,14 +9,14 @@ export const name = 'yjs'
  */
 export class YjsFactory {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    */
   create (updateHandler) {
     return new YjsCRDT(updateHandler)
   }
 
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    * @param {Uint8Array} bin
    * @return {AbstractCrdt}
    */
@@ -36,15 +36,13 @@ export class YjsFactory {
  */
 export class YjsCRDT {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    */
   constructor (updateHandler) {
     this.ydoc = new Y.Doc()
-    if (updateHandler) {
-      this.ydoc.on('updateV2', update => {
-        updateHandler(update)
-      })
-    }
+    this.ydoc.on('updateV2', update => {
+      updateHandler(update)
+    })
     this.yarray = this.ydoc.getArray('array')
     this.ymap = this.ydoc.getMap('map')
     this.ytext = this.ydoc.getText('text')

--- a/benchmarks/ywasm/bundle.js
+++ b/benchmarks/ywasm/bundle.js
@@ -1,1 +1,1 @@
-export * from 'ywasm'
+export { YDoc, applyUpdateV2, encodeStateAsUpdateV2 } from 'ywasm'

--- a/benchmarks/ywasm/factory.js
+++ b/benchmarks/ywasm/factory.js
@@ -9,14 +9,14 @@ export const name = 'ywasm'
  */
 export class YwasmFactory {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    */
   create (updateHandler) {
     return new YwasmCRDT(updateHandler)
   }
 
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    * @param {Uint8Array} bin
    * @return {AbstractCrdt}
    */
@@ -36,15 +36,13 @@ export class YwasmFactory {
  */
 export class YwasmCRDT {
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    */
   constructor (updateHandler) {
     this.ydoc = new Y.YDoc()
-    if (updateHandler) {
-      this.ydoc.onUpdateV2(update => {
-        updateHandler(update)
-      })
-    }
+    this.ydoc.onUpdateV2(/** @param {Uint8Array} update */ update => {
+      updateHandler(update)
+    })
     this.yarray = this.ydoc.getArray('array')
     this.ymap = this.ydoc.getMap('map')
     this.ytext = this.ydoc.getText('text')

--- a/js-lib/b1.js
+++ b/js-lib/b1.js
@@ -23,7 +23,7 @@ export const runBenchmarksB1 = async (crdtFactory, filter) => {
     {
       const doc1Updates = []
       const doc1 = crdtFactory.create(update => { doc1Updates.push(update) })
-      const doc2 = crdtFactory.create()
+      const doc2 = crdtFactory.create(() => {})
       benchmarkTime(crdtFactory.getName(), `${id} (time)`, () => {
         for (let i = 0; i < inputData.length; i++) {
           changeFunction(doc1, inputData[i], i)

--- a/js-lib/b4.js
+++ b/js-lib/b4.js
@@ -1,5 +1,4 @@
 import { setBenchmarkResult, benchmarkTime, logMemoryUsed, getMemUsed, tryGc, runBenchmark } from './utils.js'
-import * as math from 'lib0/math'
 import * as t from 'lib0/testing'
 import { CrdtFactory, AbstractCrdt } from './index.js' // eslint-disable-line
 // @ts-ignore
@@ -21,7 +20,7 @@ export const runBenchmarkB4 = async (crdtFactory, filter) => {
     let encodedState = /** @type {any} */ (null)
     ;(() => {
       // We scope the creation of doc1 so we can gc it before we parse it again.
-      const doc1 = crdtFactory.create()
+      const doc1 = crdtFactory.create(() => {})
       benchmarkTime(crdtFactory.getName(), `${id} (time)`, () => {
         for (let i = 0; i < inputData.length; i++) {
           changeFunction(doc1, inputData[i], i)
@@ -70,7 +69,7 @@ export const runBenchmarkB4 = async (crdtFactory, filter) => {
     let encodedState = /** @type {any} */ (null)
 
     ;(() => {
-      const doc = crdtFactory.create()
+      const doc = crdtFactory.create(() => {})
 
       benchmarkTime(crdtFactory.getName(), `${benchmarkName} (time)`, () => {
         for (let iterations = 0; iterations < multiplicator; iterations++) {

--- a/js-lib/rollup-helper.js
+++ b/js-lib/rollup-helper.js
@@ -24,7 +24,7 @@ export default [{
   input: './bundle.js',
   output: {
     dir: './dist',
-    format: 'iife'
+    format: 'esm'
   },
   plugins: [
     nodeResolve({

--- a/js-lib/rollup-helper.js
+++ b/js-lib/rollup-helper.js
@@ -1,9 +1,9 @@
 import nodeResolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
-import builtins from 'rollup-plugin-node-builtins'
-import globals from 'rollup-plugin-node-globals'
+// import builtins from 'rollup-plugin-node-builtins'
+// import globals from 'rollup-plugin-node-globals'
 import { terser } from 'rollup-plugin-terser'
-import { wasm } from '@rollup/plugin-wasm';
+import { wasm } from '@rollup/plugin-wasm'
 
 const terserPlugin = terser({
   module: true,
@@ -21,6 +21,20 @@ const terserPlugin = terser({
 })
 
 export default [{
+  input: './bundle.js',
+  output: {
+    dir: './dist',
+    format: 'iife'
+  },
+  plugins: [
+    nodeResolve({
+      mainFields: ['module', 'browser', 'main']
+    }),
+    commonjs(),
+    wasm(),
+    terserPlugin
+  ]
+}, {
   input: './run.js',
   output: {
     file: './dist/benchmark-browser.js',
@@ -33,43 +47,11 @@ export default [{
     }
   },
   plugins: [
-    wasm(),
     nodeResolve({
       mainFields: ['module', 'browser', 'main']
     }),
-    commonjs()
+    commonjs(),
+    wasm()
   ],
   external: ['fs', 'util', 'path']
-}, {
-  input: './run.js',
-  output: {
-    file: './dist/benchmark-node.js',
-    format: 'es',
-    sourcemap: true
-  },
-  plugins: [
-    nodeResolve({
-      mainFields: ['module', 'main']
-    }),
-    commonjs()
-  ],
-  external: ['isomorphic.js']
-},
-{
-  input: './bundle.js',
-  output: {
-    dir: './dist',
-    format: 'iife'
-  },
-  plugins: [
-    wasm(),
-    nodeResolve({
-      mainFields: ['main', 'module', 'main'],
-      preferBuiltins: false
-    }),
-    commonjs(),
-    builtins(),
-    globals(),
-    terserPlugin
-  ]
 }]

--- a/js-lib/utils.js
+++ b/js-lib/utils.js
@@ -127,7 +127,7 @@ export const deltaDeleteHelper = (doc, index, length) => {
 
 export class CrdtFactory {
   /**
-   * @param {function(Uint8Array|string):void} [updateHandler]
+   * @param {function(Uint8Array|string):void} updateHandler
    * @return {AbstractCrdt}
    */
   create (updateHandler) {
@@ -135,7 +135,7 @@ export class CrdtFactory {
   }
 
   /**
-   * @param {function(Uint8Array):void} [updateHandler]
+   * @param {function(Uint8Array):void} updateHandler
    * @param {Uint8Array} bin
    * @return {AbstractCrdt}
    */
@@ -164,10 +164,10 @@ export class CrdtFactory {
  */
 export class AbstractCrdt {
   /**
-   * @param {function(Uint8Array|string):void} [updateHandler]
+   * @param {function(Uint8Array|string):void} updateHandler
    * @param {Uint8Array} [init]
    */
-  constructor (updateHandler, init) {
+  constructor (updateHandler, init) { // eslint-disable-line
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "rollup-plugin-node-globals": "^1.4.0",
         "rollup-plugin-terser": "^7.0.2",
         "standard": "^16.0.3",
-        "typescript": "^3.9.6"
+        "typescript": "^5.3.3"
       },
       "engines": {
         "node": "^20.0.0"
@@ -4169,16 +4169,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -7594,9 +7594,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "workspaces": [
     "benchmarks/yjs",
     "benchmarks/ywasm",
+    "benchmarks/loro",
     "benchmarks/automerge",
     "benchmarks/automerge-wasm"
   ],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "npm run start -ws",
     "start:bun": "npm run start:bun -ws",
-    "table": "node bin/render-table.js benchmarks/results.json 6000 yjs ywasm automerge",
+    "table": "node bin/render-table.js benchmarks/results.json 6000 yjs ywasm loro automerge",
     "lint": "standard && tsc"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-terser": "^7.0.2",
     "standard": "^16.0.3",
-    "typescript": "^3.9.6"
+    "typescript": "^5.3.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,5 +60,5 @@
     // "types": ["./src/utils/typedefs.js"]
   },
   "include": ["./benchmarks/*/*.js", "./js-lib/*.js", "bin/render-table.js", "bin/measure-bundle.js", "bin/b4-benford-law.js"],
-  "exclude": ["../lib0/**/*", "node_modules/**/*", "**/dist"]
+  "exclude": ["../lib0/**/*", "node_modules/**/*", "**/dist", "benchmarks/loro/node_modules/**/*", "benchmarks/loro/node_modules/**/*"]
 }


### PR DESCRIPTION
Hi @loro-dev, @zxch3n @Leeeon233,

After looking at the benchmarks at [your website](https://www.loro.dev/docs/performance), I wanted to reproduce your results. Unfortunately, I can't find your fork of my benchmarking suite in your organization. So I integrated Loro in my benchmarking suite. Please feel free to maintain your benchmarks in this repository!

My benchmark results look very different from what you stated on your website. While you state that `parseTime` and `time` are almost (a lot) smaller than Yjs, I find the exact opposite here. In some cases, Loro seems to have exponential runtime behavior (e.g. in the B2 & B3 benchmarks, both `time` and `parseTime` increase exponentially with N). B4x100 takes several hours to execute, not just mere seconds as you stated.

Can you please explain the disparity between these results? Is there some hidden API that I'm supposed to use?

Below, I compiled a table that shows the disparity.

### Disparity between benchmark results

|N = 6000 | loro | loro-website|
| :- |  -: | -:  |
|[B3.1] 20√N clients concurrently set number in Map (time)                 |         1,895 ms |            23 ms |
|[B3.1] 20√N clients concurrently set number in Map (updateSize)           |    161,636 bytes |     63,850 bytes |
|[B3.1] 20√N clients concurrently set number in Map (encodeTime)           |             1 ms |             2 ms |
|[B3.1] 20√N clients concurrently set number in Map (docSize)              |     21,487 bytes |     38,464 bytes |
|[B3.1] 20√N clients concurrently set number in Map (parseTime)            |             4 ms |            22 ms |
|[B3.2] 20√N clients concurrently set Object in Map (time)                 |         **2,008 ms** |            40 ms |
|[B3.2] 20√N clients concurrently set Object in Map (updateSize)           |    200,630 bytes |     99,763 bytes |
|[B3.2] 20√N clients concurrently set Object in Map (encodeTime)           |             3 ms |             3 ms |
|[B3.2] 20√N clients concurrently set Object in Map (docSize)              |     40,475 bytes |     74,377 bytes |
|[B3.2] 20√N clients concurrently set Object in Map (parseTime)            |            24 ms |            24 ms |
|[B3.3] 20√N clients concurrently set String in Map (time)                 |         **2,006 ms** |           100 ms |
|[B3.3] 20√N clients concurrently set String in Map (updateSize)           |  7,940,240 bytes |  7,840,873 bytes |
|[B3.3] 20√N clients concurrently set String in Map (encodeTime)           |            47 ms |            28 ms |
|[B3.3] 20√N clients concurrently set String in Map (docSize)              |  7,799,720 bytes |  7,815,449 bytes |
|[B3.3] 20√N clients concurrently set String in Map (parseTime)            |            36 ms |             7 ms |
|[B3.4] 20√N clients concurrently insert text in Array (time)              |       **108,260 ms** |            28 ms |
|[B3.4] 20√N clients concurrently insert text in Array (updateSize)        |    166,750 bytes |     70,476 bytes |
|[B3.4] 20√N clients concurrently insert text in Array (encodeTime)        |             2 ms |             1 ms |
|[B3.4] 20√N clients concurrently insert text in Array (docSize)           |     28,140 bytes |     47,868 bytes |
|[B3.4] 20√N clients concurrently insert text in Array (parseTime)         |           **220 ms** |             5 ms |
|[B4] Apply real-world editing dataset (time)                              |         **1,264 ms** |           158 ms |
|[B4] Apply real-world editing dataset (encodeTime)                        |             6 ms |             2 ms |
|[B4] Apply real-world editing dataset (docSize)                           |    229,732 bytes |    260,815 bytes |
|[B4] Apply real-world editing dataset (parseTime)                         |            **77 ms** |             **2 ms** |
|[B4x100] Apply real-world editing dataset 100 times (time)                |          *hours..* |        15,251 ms |
|[B4x100] Apply real-world editing dataset 100 times (encodeTime)          |          skipped |           222 ms |
|[B4x100] Apply real-world editing dataset 100 times (docSize)             |          skipped | 26,826,425 bytes |
|[B4x100] Apply real-world editing dataset 100 times (parseTime)           |          skipped |           180 ms |

### Loro Website Benchmarks (extracted January 23, 2024)

|N = 6000|	loro-wasm	|yjs	|automerge-wasm |	ywasm|
| :- |  -: | -: | -: | -:  |
| [B1.1] Append N characters (time) | 54 ms | 86 ms | 61 ms | 72 ms |
| [B1.1] Append N characters (avgUpdateSize) | 58 bytes | 27 bytes | 121 bytes | 27 bytes |
| [B1.1] Append N characters (encodeTime) | 0 ms | 1 ms | 7 ms | 0 ms |
| [B1.1] Append N characters (docSize) | 6219 bytes | 6031 bytes | 3995 bytes | 6031 bytes |
| [B1.1] Append N characters (parseTime) | 0 ms | 0 ms | 38 ms | 0 ms |
| [B1.2] Insert string of length N (time) | 0 ms | 1 ms | 28 ms | 0 ms |
| [B1.2] Insert string of length N (avgUpdateSize) | 6096 bytes | 6031 bytes | 6201 bytes | 6031 bytes |
| [B1.2] Insert string of length N (encodeTime) | 0 ms | 2 ms | 2 ms | 0 ms |
| [B1.2] Insert string of length N (docSize) | 6148 bytes | 6031 bytes | 3977 bytes | 6031 bytes |
| [B1.2] Insert string of length N (parseTime) | 0 ms | 0 ms | 12 ms | 0 ms |
| [B1.3] Prepend N characters (time) | 23 ms | 73 ms | 45 ms | 16 ms |
| [B1.3] Prepend N characters (avgUpdateSize) | 57 bytes | 27 bytes | 116 bytes | 27 bytes |
| [B1.3] Prepend N characters (encodeTime) | 1 ms | 2 ms | 8 ms | 0 ms |
| [B1.3] Prepend N characters (docSize) | 6165 bytes | 6041 bytes | 3991 bytes | 6041 bytes |
| [B1.3] Prepend N characters (parseTime) | 1 ms | 5 ms | 34 ms | 1 ms |
| [B1.4] Insert N characters at random positions (time) | 19 ms | 68 ms | 214 ms | 80 ms |
| [B1.4] Insert N characters at random positions (avgUpdateSize) | 58 bytes | 29 bytes | 121 bytes | 29 bytes |
| [B1.4] Insert N characters at random positions (encodeTime) | 1 ms | 2 ms | 8 ms | 0 ms |
| [B1.4] Insert N characters at random positions (docSize) | 29503 bytes | 29554 bytes | 24746 bytes | 29554 bytes |
| [B1.4] Insert N characters at random positions (parseTime) | 1 ms | 3 ms | 64 ms | 3 ms |
| [B1.5] Insert N words at random positions (time) | 20 ms | 71 ms | 986 ms | 245 ms |
| [B1.5] Insert N words at random positions (avgUpdateSize) | 63 bytes | 36 bytes | 131 bytes | 36 bytes |
| [B1.5] Insert N words at random positions (encodeTime) | 2 ms | 3 ms | 23 ms | 1 ms |
| [B1.5] Insert N words at random positions (docSize) | 98899 bytes | 87924 bytes | 96206 bytes | 87924 bytes |
| [B1.5] Insert N words at random positions (parseTime) | 2 ms | 8 ms | 144 ms | 5 ms |
| [B1.6] Insert string, then delete it (time) | 0 ms | 5 ms | 36 ms | 0 ms |
| [B1.6] Insert string, then delete it (avgUpdateSize) | 6191 bytes | 6053 bytes | 6338 bytes | 6053 bytes |
| [B1.6] Insert string, then delete it (encodeTime) | 0 ms | 0 ms | 4 ms | 0 ms |
| [B1.6] Insert string, then delete it (docSize) | 6143 bytes | 38 bytes | 3996 bytes | 38 bytes |
| [B1.6] Insert string, then delete it (parseTime) | 0 ms | 0 ms | 28 ms | 0 ms |
| [B1.7] Insert/Delete strings at random positions (time) | 28 ms | 85 ms | 763 ms | 74 ms |
| [B1.7] Insert/Delete strings at random positions (avgUpdateSize) | 61 bytes | 31 bytes | 135 bytes | 31 bytes |
| [B1.7] Insert/Delete strings at random positions (encodeTime) | 1 ms | 7 ms | 18 ms | 0 ms |
| [B1.7] Insert/Delete strings at random positions (docSize) | 51470 bytes | 28377 bytes | 59284 bytes | 28377 bytes |
| [B1.7] Insert/Delete strings at random positions (parseTime) | 1 ms | 10 ms | 112 ms | 2 ms |
| [B1.8] Append N numbers (time) | 23 ms | 85 ms | 146 ms | 16 ms |
| [B1.8] Append N numbers (avgUpdateSize) | 60 bytes | 32 bytes | 125 bytes | 32 bytes |
| [B1.8] Append N numbers (encodeTime) | 2 ms | 1 ms | 10 ms | 0 ms |
| [B1.8] Append N numbers (docSize) | 47623 bytes | 35634 bytes | 26988 bytes | 35634 bytes |
| [B1.8] Append N numbers (parseTime) | 3 ms | 0 ms | 68 ms | 0 ms |
| [B1.9] Insert Array of N numbers (time) | 5 ms | 1 ms | 24 ms | 2 ms |
| [B1.9] Insert Array of N numbers (avgUpdateSize) | 35725 bytes | 35657 bytes | 31199 bytes | 35657 bytes |
| [B1.9] Insert Array of N numbers (encodeTime) | 1 ms | 1 ms | 2 ms | 0 ms |
| [B1.9] Insert Array of N numbers (docSize) | 47648 bytes | 35657 bytes | 26956 bytes | 35657 bytes |
| [B1.9] Insert Array of N numbers (parseTime) | 3 ms | 0 ms | 23 ms | 0 ms |
| [B1.10] Prepend N numbers (time) | 16 ms | 51 ms | 382 ms | 15 ms |
| [B1.10] Prepend N numbers (avgUpdateSize) | 59 bytes | 32 bytes | 120 bytes | 32 bytes |
| [B1.10] Prepend N numbers (encodeTime) | 1 ms | 1 ms | 10 ms | 0 ms |
| [B1.10] Prepend N numbers (docSize) | 47643 bytes | 35665 bytes | 26990 bytes | 35665 bytes |
| [B1.10] Prepend N numbers (parseTime) | 3 ms | 1 ms | 51 ms | 2 ms |
| [B1.11] Insert N numbers at random positions (time) | 16 ms | 58 ms | 458 ms | 113 ms |
| [B1.11] Insert N numbers at random positions (avgUpdateSize) | 62 bytes | 34 bytes | 125 bytes | 34 bytes |
| [B1.11] Insert N numbers at random positions (encodeTime) | 1 ms | 2 ms | 12 ms | 0 ms |
| [B1.11] Insert N numbers at random positions (docSize) | 70903 bytes | 59137 bytes | 47749 bytes | 59137 bytes |
| [B1.11] Insert N numbers at random positions (parseTime) | 3 ms | 3 ms | 70 ms | 3 ms |
| [B2.1] Concurrently insert string of length N at index 0 (time) | 0 ms | 0 ms | 104 ms | 0 ms |
| [B2.1] Concurrently insert string of length N at index 0 (updateSize) | 9256 bytes | 6094 bytes | 9499 bytes | 6093 bytes |
| [B2.1] Concurrently insert string of length N at index 0 (encodeTime) | 0 ms | 0 ms | 4 ms | 0 ms |
| [B2.1] Concurrently insert string of length N at index 0 (docSize) | 12282 bytes | 12152 bytes | 8014 bytes | 12150 bytes |
| [B2.1] Concurrently insert string of length N at index 0 (parseTime) | 0 ms | 0 ms | 43 ms | 0 ms |
| [B2.2] Concurrently insert N characters at random positions (time) | 117 ms | 25 ms | 1496 ms | 210 ms |
| [B2.2] Concurrently insert N characters at random positions (updateSize) | 344345 bytes | 33444 bytes | 1093293 bytes | 177007 bytes |
| [B2.2] Concurrently insert N characters at random positions (encodeTime) | 1 ms | 2 ms | 18 ms | 1 ms |
| [B2.2] Concurrently insert N characters at random positions (docSize) | 59356 bytes | 66860 bytes | 50708 bytes | 66852 bytes |
| [B2.2] Concurrently insert N characters at random positions (parseTime) | 2 ms | 15 ms | 142 ms | 6 ms |
| [B2.3] Concurrently insert N words at random positions (time) | 144 ms | 55 ms | 2915 ms | 569 ms |
| [B2.3] Concurrently insert N words at random positions (updateSize) | 408728 bytes | 88994 bytes | 1185202 bytes | 215213 bytes |
| [B2.3] Concurrently insert N words at random positions (encodeTime) | 3 ms | 4 ms | 48 ms | 4 ms |
| [B2.3] Concurrently insert N words at random positions (docSize) | 197284 bytes | 178130 bytes | 191500 bytes | 178130 bytes |
| [B2.3] Concurrently insert N words at random positions (parseTime) | 3 ms | 13 ms | 311 ms | 11 ms |
| [B2.4] Concurrently insert & delete (time) | 259 ms | 95 ms | 5682 ms | 1500 ms |
| [B2.4] Concurrently insert & delete (updateSize) | 786130 bytes | 139517 bytes | 2395876 bytes | 398881 bytes |
| [B2.4] Concurrently insert & delete (encodeTime) | 4 ms | 6 ms | 87 ms | 5 ms |
| [B2.4] Concurrently insert & delete (docSize) | 304590 bytes | 279166 bytes | 307364 bytes | 279172 bytes |
| [B2.4] Concurrently insert & delete (parseTime) | 4 ms | 27 ms | 444 ms | 32 ms |
| [B3.1] 20√N clients concurrently set number in Map (time) | 23 ms | 52 ms | 35 ms | 156 ms |
| [B3.1] 20√N clients concurrently set number in Map (updateSize) | 63850 bytes | 49163 bytes | 283296 bytes | 49172 bytes |
| [B3.1] 20√N clients concurrently set number in Map (encodeTime) | 2 ms | 2 ms | 13 ms | 1 ms |
| [B3.1] 20√N clients concurrently set number in Map (docSize) | 38464 bytes | 32212 bytes | 83205 bytes | 32214 bytes |
| [B3.1] 20√N clients concurrently set number in Map (parseTime) | 22 ms | 14 ms | 38 ms | 10 ms |
| [B3.2] 20√N clients concurrently set Object in Map (time) | 40 ms | 50 ms | 42 ms | 156 ms |
| [B3.2] 20√N clients concurrently set Object in Map (updateSize) | 99763 bytes | 85077 bytes | 325370 bytes | 85083 bytes |
| [B3.2] 20√N clients concurrently set Object in Map (encodeTime) | 3 ms | 2 ms | 20 ms | 1 ms |
| [B3.2] 20√N clients concurrently set Object in Map (docSize) | 74377 bytes | 32223 bytes | 90426 bytes | 32240 bytes |
| [B3.2] 20√N clients concurrently set Object in Map (parseTime) | 24 ms | 13 ms | 34 ms | 11 ms |
| [B3.3] 20√N clients concurrently set String in Map (time) | 100 ms | 70 ms | 215 ms | 167 ms |
| [B3.3] 20√N clients concurrently set String in Map (updateSize) | 7840873 bytes | 7826231 bytes | 8063440 bytes | 7826231 bytes |
| [B3.3] 20√N clients concurrently set String in Map (encodeTime) | 28 ms | 2 ms | 52 ms | 2 ms |
| [B3.3] 20√N clients concurrently set String in Map (docSize) | 7815449 bytes | 38369 bytes | 95086 bytes | 36840 bytes |
rt & delete (parseTime) | 4 ms | 27 ms | 444 ms | 32 ms |
| [B3.1] 20√N clients concurrently set number in Map (time) | 23 ms | 52 ms | 35 ms | 156 ms |
| [B3.1] 20√N clients concurrently set number in Map (updateSize) | 63850 bytes | 49163 bytes | 283296 bytes | 49172 bytes |
| [B3.1] 20√N clients concurrently set number in Map (encodeTime) | 2 ms | 2 ms | 13 ms | 1 ms |
| [B3.1] 20√N clients concurrently set number in Map (docSize) | 38464 bytes | 32212 bytes | 83205 bytes | 32214 bytes |
| [B3.1] 20√N clients concurrently set number in Map (parseTime) | 22 ms | 14 ms | 38 ms | 10 ms |
| [B3.2] 20√N clients concurrently set Object in Map (time) | 40 ms | 50 ms | 42 ms | 156 ms |
| [B3.2] 20√N clients concurrently set Object in Map (updateSize) | 99763 bytes | 85077 bytes | 325370 bytes | 85083 bytes |
| [B3.2] 20√N clients concurrently set Object in Map (encodeTime) | 3 ms | 2 ms | 20 ms | 1 ms |
| [B3.2] 20√N clients concurrently set Object in Map (docSize) | 74377 bytes | 32223 bytes | 90426 bytes | 32240 bytes |
| [B3.2] 20√N clients concurrently set Object in Map (parseTime) | 24 ms | 13 ms | 34 ms | 11 ms |
| [B3.3] 20√N clients concurrently set String in Map (time) | 100 ms | 70 ms | 215 ms | 167 ms |
| [B3.3] 20√N clients concurrently set String in Map (updateSize) | 7840873 bytes | 7826231 bytes | 8063440 bytes | 7826231 bytes |
| [B3.3] 20√N clients concurrently set String in Map (encodeTime) | 28 ms | 2 ms | 52 ms | 2 ms |
| [B3.3] 20√N clients concurrently set String in Map (docSize) | 7815449 bytes | 38369 bytes | 95086 bytes | 36840 bytes |
| [B3.3] 20√N clients concurrently set String in Map (parseTime) | 7 ms | 13 ms | 74 ms | 14 ms |
| [B3.4] 20√N clients concurrently insert text in Array (time) | 28 ms | 44 ms | 33 ms | 165 ms |
| [B3.4] 20√N clients concurrently insert text in Array (updateSize) | 70476 bytes | 52745 bytes | 285330 bytes | 52737 bytes |
| [B3.4] 20√N clients concurrently insert text in Array (encodeTime) | 1 ms | 2 ms | 19 ms | 1 ms |
| [B3.4] 20√N clients concurrently insert text in Array (docSize) | 47868 bytes | 26590 bytes | 83577 bytes | 26582 bytes |
| [B3.4] 20√N clients concurrently insert text in Array (parseTime) | 5 ms | 2 ms | 41 ms | 4 ms |
| [B4] Apply real-world editing dataset (time) | 158 ms | 1028 ms | 1542 ms | 23006 ms |
| [B4] Apply real-world editing dataset (avgUpdateSize) | skipped | 29 bytes | skipped | skipped |
| [B4] Apply real-world editing dataset (encodeTime) | 2 ms | 4 ms | 131 ms | 3 ms |
| [B4] Apply real-world editing dataset (docSize) | 260815 bytes | 159929 bytes | 129098 bytes | 159929 bytes |
| [B4] Apply real-world editing dataset (parseTime) | 2 ms | 6 ms | 615 ms | 14 ms |
| [B4x100] Apply real-world editing dataset 100 times (time) | 15251 ms | 110404 ms | skipped | skipped |
| [B4x100] Apply real-world editing dataset 100 times (encodeTime) | 222 ms | 266 ms | skipped | skipped |
| [B4x100] Apply real-world editing dataset 100 times (docSize) | 26826425 bytes | 15989245 bytes | skipped | skipped |
| [B4x100] Apply real-world editing dataset 100 times (parseTime) | 180 ms | 1357 ms | skipped | skipped |